### PR TITLE
feat: implement custom version of libp2p-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,12 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1_der"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,28 +118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bitflags"
@@ -184,12 +160,6 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bs58"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
@@ -309,12 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,15 +289,6 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -385,33 +340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
-name = "data-encoding-macro"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
-dependencies = [
- "data-encoding",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
- "zeroize",
+ "der_derive",
 ]
 
 [[package]]
@@ -426,6 +360,18 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -478,15 +424,9 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -516,34 +456,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -585,7 +501,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -606,17 +521,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-rustls"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
-dependencies = [
- "futures-io",
- "rustls",
- "webpki",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,12 +531,6 @@ name = "futures-task"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -721,30 +619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "indicatif"
@@ -757,15 +641,6 @@ dependencies = [
  "portable-atomic",
  "tokio",
  "unicode-width",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -800,15 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,58 +706,6 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
-name = "libp2p-core"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "instant",
- "log",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "rw-stream-sink",
- "sec1",
- "sha2 0.10.6",
- "smallvec",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.1.0-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core",
- "rcgen",
- "ring",
- "rustls",
- "thiserror",
- "webpki",
- "x509-parser",
- "yasna",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -958,82 +772,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
-]
-
-[[package]]
-name = "multiaddr"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
-dependencies = [
- "arrayref",
- "byteorder",
- "data-encoding",
- "multibase",
- "multihash",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
-dependencies = [
- "core2",
- "digest 0.10.6",
- "multihash-derive",
- "sha2 0.10.6",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multistream-select"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "pin-project",
- "smallvec",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -1182,22 +920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "petgraph"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,16 +952,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,26 +972,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "prettyplease"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror",
- "toml",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -1312,61 +1004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -1471,30 +1108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -1557,17 +1170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
-]
-
-[[package]]
-name = "rw-stream-sink"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26338f5e09bb721b85b135ea05af7767c90b52f6de4f087d4f4a3a9d64e7dc04"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
 ]
 
 [[package]]
@@ -1712,19 +1314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "zeroize",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,17 +1331,25 @@ dependencies = [
  "blake3",
  "bytes",
  "clap",
+ "der",
+ "ed25519-dalek",
  "futures",
+ "hex",
  "indicatif",
- "libp2p-core",
- "libp2p-tls",
  "postcard",
+ "rand 0.7.3",
+ "rcgen",
+ "ring",
+ "rustls",
  "s2n-quic",
  "serde",
  "testdir",
+ "thiserror",
  "tokio",
  "tokio-util",
  "unsigned-varint",
+ "webpki",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1797,17 +1394,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -1863,22 +1449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,20 +1494,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
  "winapi",
 ]
 
@@ -2012,21 +1568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
 name = "tokio"
 version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,40 +1612,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"
@@ -2135,27 +1652,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "url"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"
@@ -2241,17 +1741,6 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,25 @@ bao = "0.12.1"
 blake3 = "1.3.3"
 bytes = "1.3.0"
 clap = { version = "4", features = ["derive"] }
+der = { version = "0.6.1", features = ["alloc", "derive"] }
+ed25519-dalek = "1.0.1"
 futures = "0.3.25"
+hex = "0.4.3"
 indicatif = { version = "0.17.2", features = ["tokio"] }
-libp2p-core = { version = "0.38.0", features = [] }
-libp2p-tls = "0.1.0-alpha"
 postcard = { version = "1.0.2", default-features = false, features = ["alloc", "use-std"] }
+rand = "0.7"
+rcgen = "0.10.0"
+ring = "0.16.20"
+rustls = { version = "0.20.8", default-features = false, features = ["dangerous_configuration"] }
 s2n-quic = { version = "1.14.0", default-features = false, features = [ "provider-tls-rustls", "provider-address-token-default" ] }
 serde = { version = "1.0.152", features = ["derive"] }
+thiserror = "1.0.38"
 tokio = { version = "1.24.1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io-util", "io"] }
 unsigned-varint = { version = "0.7.1", features = ["futures"] }
+webpki = "0.22.0"
+x509-parser = "0.14.0"
+
 
 [dev-dependencies]
 testdir = "0.7.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,11 +2,11 @@ use std::{io::Read, net::SocketAddr, path::PathBuf, time::Instant};
 
 use anyhow::{anyhow, bail, ensure, Result};
 use bytes::BytesMut;
-use libp2p_core::identity::ed25519::Keypair;
 use s2n_quic::{client::Connect, Client};
 use tokio::io::AsyncReadExt;
 
 use crate::protocol::{write_lp, Request, Res, Response};
+use crate::tls::{self, Keypair};
 
 const MAX_DATA_SIZE: usize = 1024 * 1024 * 1024;
 
@@ -17,9 +17,9 @@ pub struct Options {
 }
 
 pub async fn run(hash: bao::Hash, opts: Options) -> Result<()> {
-    let keypair = libp2p_core::identity::Keypair::Ed25519(Keypair::generate());
+    let keypair = Keypair::generate();
 
-    let client_config = libp2p_tls::make_client_config(&keypair, None)?;
+    let client_config = tls::make_client_config(&keypair, None)?;
     let tls = s2n_quic::provider::tls::rustls::Client::from(client_config);
 
     let client = Client::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod client;
 pub mod protocol;
 pub mod server;
 
+mod tls;
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 
 use anyhow::{anyhow, ensure, Result};
 use bytes::{Bytes, BytesMut};
-use libp2p_core::identity::ed25519::Keypair;
 use s2n_quic::Server;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::protocol::{write_lp, Request, Res, Response};
+use crate::tls::{self, Keypair};
 
 #[derive(Clone, Debug, Default)]
 pub struct Options {
@@ -14,8 +14,8 @@ pub struct Options {
 }
 
 pub async fn run(db: Arc<HashMap<bao::Hash, Data>>, opts: Options) -> Result<()> {
-    let keypair = libp2p_core::identity::Keypair::Ed25519(Keypair::generate());
-    let server_config = libp2p_tls::make_server_config(&keypair)?;
+    let keypair = Keypair::generate();
+    let server_config = tls::make_server_config(&keypair)?;
     let tls = s2n_quic::provider::tls::rustls::Server::from(server_config);
     let limits = s2n_quic::provider::limits::Default::default();
     let port = if let Some(port) = opts.port {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,120 @@
+//! TLS configuration based on libp2p TLS specs.
+//!
+//! See <https://github.com/libp2p/specs/blob/master/tls/tls.md>.
+//! Based on rust-libp2p/transports/tls
+
+pub mod certificate;
+mod verifier;
+
+use std::{
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
+};
+
+pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
+
+// TODO: change?
+const P2P_ALPN: [u8; 6] = *b"libp2p";
+
+#[derive(Debug)]
+pub struct Keypair(ed25519_dalek::Keypair);
+
+impl Keypair {
+    pub fn public(&self) -> PublicKey {
+        self.0.public
+    }
+
+    pub fn generate() -> Self {
+        let mut rng = rand::rngs::OsRng;
+        let key = ed25519_dalek::Keypair::generate(&mut rng);
+        Self(key)
+    }
+
+    fn sign(&self, msg: &[u8]) -> Signature {
+        use ed25519_dalek::Signer;
+
+        self.0.sign(msg)
+    }
+}
+
+// TODO: probably needs a version field
+#[derive(Clone, PartialEq)]
+pub struct PeerId(PublicKey);
+
+impl From<PublicKey> for PeerId {
+    fn from(key: PublicKey) -> Self {
+        PeerId(key)
+    }
+}
+
+impl Debug for PeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PeerId({})", hex::encode(self.0.as_bytes()))
+    }
+}
+
+impl Display for PeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.0.as_bytes()))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PeerIdError {
+    #[error("encoding: {0}")]
+    Hex(#[from] hex::FromHexError),
+    #[error("key: {0}")]
+    Key(#[from] ed25519_dalek::SignatureError),
+}
+
+impl FromStr for PeerId {
+    type Err = PeerIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = hex::decode(s)?;
+        let key = PublicKey::from_bytes(&bytes)?;
+        Ok(PeerId(key))
+    }
+}
+
+/// Create a TLS client configuration.
+pub fn make_client_config(
+    keypair: &Keypair,
+    remote_peer_id: Option<PeerId>,
+) -> Result<rustls::ClientConfig, certificate::GenError> {
+    let (certificate, private_key) = certificate::generate(keypair)?;
+
+    let mut crypto = rustls::ClientConfig::builder()
+        .with_cipher_suites(verifier::CIPHERSUITES)
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
+        .expect("Cipher suites and kx groups are configured; qed")
+        .with_custom_certificate_verifier(Arc::new(
+            verifier::Libp2pCertificateVerifier::with_remote_peer_id(remote_peer_id),
+        ))
+        .with_single_cert(vec![certificate], private_key)
+        .expect("Client cert key DER is valid; qed");
+    crypto.alpn_protocols = vec![P2P_ALPN.to_vec()];
+
+    Ok(crypto)
+}
+
+/// Create a TLS server configuration.
+pub fn make_server_config(
+    keypair: &Keypair,
+) -> Result<rustls::ServerConfig, certificate::GenError> {
+    let (certificate, private_key) = certificate::generate(keypair)?;
+
+    let mut crypto = rustls::ServerConfig::builder()
+        .with_cipher_suites(verifier::CIPHERSUITES)
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(verifier::PROTOCOL_VERSIONS)
+        .expect("Cipher suites and kx groups are configured; qed")
+        .with_client_cert_verifier(Arc::new(verifier::Libp2pCertificateVerifier::new()))
+        .with_single_cert(vec![certificate], private_key)
+        .expect("Server cert key DER is valid; qed");
+    crypto.alpn_protocols = vec![P2P_ALPN.to_vec()];
+
+    Ok(crypto)
+}

--- a/src/tls/certificate.rs
+++ b/src/tls/certificate.rs
@@ -1,0 +1,383 @@
+//! X.509 certificate handling.
+//!
+//! This module handles generation, signing, and verification of certificates.
+
+use der::{asn1::OctetStringRef, Decode, Encode, Sequence};
+use x509_parser::prelude::*;
+
+use super::{Keypair, PeerId, PublicKey, Signature};
+
+/// The libp2p Public Key Extension is a X.509 extension
+/// with the Object Identier 1.3.6.1.4.1.53594.1.1,
+/// allocated by IANA to the libp2p project at Protocol Labs.
+const P2P_EXT_OID: [u64; 9] = [1, 3, 6, 1, 4, 1, 53594, 1, 1];
+
+/// The peer signs the concatenation of the string `libp2p-tls-handshake:`
+/// and the public key that it used to generate the certificate carrying
+/// the libp2p Public Key Extension, using its private host key.
+/// This signature provides cryptographic proof that the peer was
+/// in possession of the private host key at the time the certificate was signed.
+const P2P_SIGNING_PREFIX: [u8; 21] = *b"libp2p-tls-handshake:";
+
+// Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
+// Similarly, hash functions with an output length less than 256 bits MUST NOT be used.
+static P2P_SIGNATURE_ALGORITHM: &rcgen::SignatureAlgorithm = &rcgen::PKCS_ECDSA_P256_SHA256;
+
+/// The public host key and the signature are ANS.1-encoded
+/// into the SignedKey data structure, which is carried  in the libp2p Public Key Extension.
+#[derive(Clone, Debug, Eq, PartialEq, Sequence)]
+struct SignedKey<'a> {
+    public_key: OctetStringRef<'a>,
+    signature: OctetStringRef<'a>,
+}
+
+/// Generates a self-signed TLS certificate that includes a libp2p-specific
+/// certificate extension containing the public key of the given keypair.
+pub fn generate(
+    identity_keypair: &Keypair,
+) -> Result<(rustls::Certificate, rustls::PrivateKey), GenError> {
+    // Keypair used to sign the certificate.
+    // SHOULD NOT be related to the host's key.
+    // Endpoints MAY generate a new key and certificate
+    // for every connection attempt, or they MAY reuse the same key
+    // and certificate for multiple connections.
+    let certificate_keypair = rcgen::KeyPair::generate(P2P_SIGNATURE_ALGORITHM)?;
+    let rustls_key = rustls::PrivateKey(certificate_keypair.serialize_der());
+
+    let certificate = {
+        let mut params = rcgen::CertificateParams::new(vec![]);
+        params.distinguished_name = rcgen::DistinguishedName::new();
+        params.custom_extensions.push(make_libp2p_extension(
+            identity_keypair,
+            &certificate_keypair,
+        )?);
+        params.alg = P2P_SIGNATURE_ALGORITHM;
+        params.key_pair = Some(certificate_keypair);
+        rcgen::Certificate::from_params(params)?
+    };
+
+    let rustls_certificate = rustls::Certificate(certificate.serialize_der()?);
+
+    Ok((rustls_certificate, rustls_key))
+}
+
+/// Attempts to parse the provided bytes as a [`P2pCertificate`].
+///
+/// For this to succeed, the certificate must contain the specified extension and the signature must
+/// match the embedded public key.
+pub fn parse(certificate: &rustls::Certificate) -> Result<P2pCertificate<'_>, ParseError> {
+    let certificate = parse_unverified(certificate.as_ref())?;
+
+    certificate.verify()?;
+
+    Ok(certificate)
+}
+
+/// An X.509 certificate with a libp2p-specific extension
+/// is used to secure libp2p connections.
+#[derive(Debug)]
+pub struct P2pCertificate<'a> {
+    certificate: X509Certificate<'a>,
+    /// This is a specific libp2p Public Key Extension with two values:
+    /// * the public host key
+    /// * a signature performed using the private host key
+    extension: P2pExtension,
+}
+
+/// The contents of the specific libp2p extension, containing the public host key
+/// and a signature performed using the private host key.
+#[derive(Debug)]
+pub struct P2pExtension {
+    public_key: super::PublicKey,
+    /// This signature provides cryptographic proof that the peer was
+    /// in possession of the private host key at the time the certificate was signed.
+    signature: super::Signature,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct GenError(#[from] rcgen::RcgenError);
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ParseError(#[from] pub(crate) webpki::Error);
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct VerificationError(#[from] pub(crate) webpki::Error);
+/// Internal function that only parses but does not verify the certificate.
+///
+/// Useful for testing but unsuitable for production.
+fn parse_unverified(der_input: &[u8]) -> Result<P2pCertificate, webpki::Error> {
+    let x509 = X509Certificate::from_der(der_input)
+        .map(|(_rest_input, x509)| x509)
+        .map_err(|_| webpki::Error::BadDer)?;
+
+    let p2p_ext_oid = der_parser::oid::Oid::from(&P2P_EXT_OID)
+        .expect("This is a valid OID of p2p extension; qed");
+
+    let mut libp2p_extension = None;
+
+    for ext in x509.extensions() {
+        let oid = &ext.oid;
+        if oid == &p2p_ext_oid && libp2p_extension.is_some() {
+            // The extension was already parsed
+            return Err(webpki::Error::BadDer);
+        }
+
+        if oid == &p2p_ext_oid {
+            let signed_key =
+                SignedKey::from_der(ext.value).map_err(|_| webpki::Error::ExtensionValueInvalid)?;
+            let public_key = PublicKey::from_bytes(&signed_key.public_key.as_bytes())
+                .map_err(|_| webpki::Error::UnknownIssuer)?;
+            let signature = Signature::from_bytes(signed_key.signature.as_bytes())
+                .map_err(|_| webpki::Error::UnknownIssuer)?;
+            let ext = P2pExtension {
+                public_key,
+                signature,
+            };
+            libp2p_extension = Some(ext);
+            continue;
+        }
+
+        if ext.critical {
+            // Endpoints MUST abort the connection attempt if the certificate
+            // contains critical extensions that the endpoint does not understand.
+            return Err(webpki::Error::UnsupportedCriticalExtension);
+        }
+
+        // Implementations MUST ignore non-critical extensions with unknown OIDs.
+    }
+
+    // The certificate MUST contain the libp2p Public Key Extension.
+    // If this extension is missing, endpoints MUST abort the connection attempt.
+    let extension = libp2p_extension.ok_or(webpki::Error::BadDer)?;
+
+    let certificate = P2pCertificate {
+        certificate: x509,
+        extension,
+    };
+
+    Ok(certificate)
+}
+
+fn make_libp2p_extension(
+    identity_keypair: &Keypair,
+    certificate_keypair: &rcgen::KeyPair,
+) -> Result<rcgen::CustomExtension, rcgen::RcgenError> {
+    // The peer signs the concatenation of the string `libp2p-tls-handshake:`
+    // and the public key that it used to generate the certificate carrying
+    // the libp2p Public Key Extension, using its private host key.
+    let signature = {
+        let mut msg = vec![];
+        msg.extend(P2P_SIGNING_PREFIX);
+        msg.extend(certificate_keypair.public_key_der());
+
+        identity_keypair.sign(&msg)
+    };
+
+    let public_key = identity_keypair.public();
+    let signature = signature.to_bytes();
+    let key = SignedKey {
+        public_key: OctetStringRef::new(&public_key.as_bytes()[..]).unwrap(),
+        signature: OctetStringRef::new(&signature).unwrap(),
+    };
+
+    let extension_content = key.to_vec().expect("vec");
+
+    // This extension MAY be marked critical.
+    let mut ext = rcgen::CustomExtension::from_oid_content(&P2P_EXT_OID, extension_content);
+    ext.set_criticality(true);
+
+    Ok(ext)
+}
+
+impl P2pCertificate<'_> {
+    /// The [`PeerId`] of the remote peer.
+    pub fn peer_id(&self) -> PeerId {
+        self.extension.public_key.into()
+    }
+
+    /// Verify the `signature` of the `message` signed by the private key corresponding to the public key stored
+    /// in the certificate.
+    pub fn verify_signature(
+        &self,
+        signature_scheme: rustls::SignatureScheme,
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), VerificationError> {
+        let pk = self.public_key(signature_scheme)?;
+        pk.verify(message, signature)
+            .map_err(|_| webpki::Error::InvalidSignatureForPublicKey)?;
+
+        Ok(())
+    }
+
+    /// Get a [`ring::signature::UnparsedPublicKey`] for this `signature_scheme`.
+    /// Return `Error` if the `signature_scheme` does not match the public key signature
+    /// and hashing algorithm or if the `signature_scheme` is not supported.
+    fn public_key(
+        &self,
+        signature_scheme: rustls::SignatureScheme,
+    ) -> Result<ring::signature::UnparsedPublicKey<&[u8]>, webpki::Error> {
+        use ring::signature;
+        use rustls::SignatureScheme::*;
+
+        let current_signature_scheme = self.signature_scheme()?;
+        if signature_scheme != current_signature_scheme {
+            // This certificate was signed with a different signature scheme
+            return Err(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey);
+        }
+
+        let verification_algorithm: &dyn signature::VerificationAlgorithm = match signature_scheme {
+            ECDSA_NISTP256_SHA256 => &signature::ECDSA_P256_SHA256_ASN1,
+            ECDSA_NISTP384_SHA384 => &signature::ECDSA_P384_SHA384_ASN1,
+            ECDSA_NISTP521_SHA512 => {
+                // See https://github.com/briansmith/ring/issues/824
+                return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+            }
+            ED25519 => &signature::ED25519,
+            ED448 => {
+                // See https://github.com/briansmith/ring/issues/463
+                return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+            }
+            // No support for RSA
+            RSA_PKCS1_SHA256 | RSA_PKCS1_SHA384 | RSA_PKCS1_SHA512 | RSA_PSS_SHA256
+            | RSA_PSS_SHA384 | RSA_PSS_SHA512 => {
+                return Err(webpki::Error::UnsupportedSignatureAlgorithm)
+            }
+            // Similarly, hash functions with an output length less than 256 bits
+            // MUST NOT be used, due to the possibility of collision attacks.
+            // In particular, MD5 and SHA1 MUST NOT be used.
+            RSA_PKCS1_SHA1 => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+            ECDSA_SHA1_Legacy => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+            Unknown(_) => return Err(webpki::Error::UnsupportedSignatureAlgorithm),
+        };
+        let spki = &self.certificate.tbs_certificate.subject_pki;
+        let key = signature::UnparsedPublicKey::new(
+            verification_algorithm,
+            spki.subject_public_key.as_ref(),
+        );
+
+        Ok(key)
+    }
+
+    /// This method validates the certificate according to libp2p TLS 1.3 specs.
+    /// The certificate MUST:
+    /// 1. be valid at the time it is received by the peer;
+    /// 2. use the NamedCurve encoding;
+    /// 3. use hash functions with an output length not less than 256 bits;
+    /// 4. be self signed;
+    /// 5. contain a valid signature in the specific libp2p extension.
+    fn verify(&self) -> Result<(), webpki::Error> {
+        use ed25519_dalek::Verifier;
+        use webpki::Error;
+
+        // The certificate MUST have NotBefore and NotAfter fields set
+        // such that the certificate is valid at the time it is received by the peer.
+        if !self.certificate.validity().is_valid() {
+            return Err(Error::InvalidCertValidity);
+        }
+
+        // Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
+        // Similarly, hash functions with an output length less than 256 bits
+        // MUST NOT be used, due to the possibility of collision attacks.
+        // In particular, MD5 and SHA1 MUST NOT be used.
+        // Endpoints MUST abort the connection attempt if it is not used.
+        let signature_scheme = self.signature_scheme()?;
+        // Endpoints MUST abort the connection attempt if the certificate’s
+        // self-signature is not valid.
+        let raw_certificate = self.certificate.tbs_certificate.as_ref();
+        let signature = self.certificate.signature_value.as_ref();
+        // check if self signed
+        self.verify_signature(signature_scheme, raw_certificate, signature)
+            .map_err(|_| Error::SignatureAlgorithmMismatch)?;
+
+        let subject_pki = self.certificate.public_key().raw;
+
+        // The peer signs the concatenation of the string `libp2p-tls-handshake:`
+        // and the public key that it used to generate the certificate carrying
+        // the libp2p Public Key Extension, using its private host key.
+        let mut msg = vec![];
+        msg.extend(P2P_SIGNING_PREFIX);
+        msg.extend(subject_pki);
+
+        // This signature provides cryptographic proof that the peer was in possession
+        // of the private host key at the time the certificate was signed.
+        // Peers MUST verify the signature, and abort the connection attempt
+        // if signature verification fails.
+        let user_owns_sk = self
+            .extension
+            .public_key
+            .verify(&msg, &self.extension.signature)
+            .is_ok();
+        if !user_owns_sk {
+            return Err(Error::UnknownIssuer);
+        }
+
+        Ok(())
+    }
+
+    /// Return the signature scheme corresponding to [`AlgorithmIdentifier`]s
+    /// of `subject_pki` and `signature_algorithm`
+    /// according to <https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.3>.
+    fn signature_scheme(&self) -> Result<rustls::SignatureScheme, webpki::Error> {
+        // Certificates MUST use the NamedCurve encoding for elliptic curve parameters.
+        // Endpoints MUST abort the connection attempt if it is not used.
+        use oid_registry::*;
+        use rustls::SignatureScheme::*;
+
+        let signature_algorithm = &self.certificate.signature_algorithm;
+        let pki_algorithm = &self.certificate.tbs_certificate.subject_pki.algorithm;
+
+        if pki_algorithm.algorithm == OID_KEY_TYPE_EC_PUBLIC_KEY {
+            let signature_param = pki_algorithm
+                .parameters
+                .as_ref()
+                .ok_or(webpki::Error::BadDer)?
+                .as_oid()
+                .map_err(|_| webpki::Error::BadDer)?;
+            if signature_param == OID_EC_P256
+                && signature_algorithm.algorithm == OID_SIG_ECDSA_WITH_SHA256
+            {
+                return Ok(ECDSA_NISTP256_SHA256);
+            }
+            if signature_param == OID_NIST_EC_P384
+                && signature_algorithm.algorithm == OID_SIG_ECDSA_WITH_SHA384
+            {
+                return Ok(ECDSA_NISTP384_SHA384);
+            }
+            if signature_param == OID_NIST_EC_P521
+                && signature_algorithm.algorithm == OID_SIG_ECDSA_WITH_SHA512
+            {
+                return Ok(ECDSA_NISTP521_SHA512);
+            }
+            return Err(webpki::Error::UnsupportedSignatureAlgorithm);
+        }
+
+        if signature_algorithm.algorithm == OID_SIG_ED25519 {
+            return Ok(ED25519);
+        }
+        if signature_algorithm.algorithm == OID_SIG_ED448 {
+            return Ok(ED448);
+        }
+
+        Err(webpki::Error::UnsupportedSignatureAlgorithm)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        let keypair = Keypair::generate();
+
+        let (cert, _) = generate(&keypair).unwrap();
+        let parsed_cert = parse(&cert).unwrap();
+
+        assert!(parsed_cert.verify().is_ok());
+        assert_eq!(keypair.public(), parsed_cert.extension.public_key);
+    }
+}

--- a/src/tls/verifier.rs
+++ b/src/tls/verifier.rs
@@ -1,0 +1,228 @@
+//! TLS 1.3 certificates and handshakes handling for libp2p
+//!
+//! This module handles a verification of a client/server certificate chain
+//! and signatures allegedly by the given certificates.
+
+use super::{certificate, PeerId};
+use rustls::{
+    cipher_suite::{
+        TLS13_AES_128_GCM_SHA256, TLS13_AES_256_GCM_SHA384, TLS13_CHACHA20_POLY1305_SHA256,
+    },
+    client::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    internal::msgs::handshake::DigitallySignedStruct,
+    server::{ClientCertVerified, ClientCertVerifier},
+    Certificate, DistinguishedNames, SignatureScheme, SupportedCipherSuite,
+    SupportedProtocolVersion,
+};
+
+/// The protocol versions supported by this verifier.
+///
+/// The spec says:
+///
+/// > The libp2p handshake uses TLS 1.3 (and higher).
+/// > Endpoints MUST NOT negotiate lower TLS versions.
+pub static PROTOCOL_VERSIONS: &[&SupportedProtocolVersion] = &[&rustls::version::TLS13];
+
+/// A list of the TLS 1.3 cipher suites supported by rustls.
+// By default rustls creates client/server configs with both
+// TLS 1.3 __and__ 1.2 cipher suites. But we don't need 1.2.
+pub static CIPHERSUITES: &[SupportedCipherSuite] = &[
+    // TLS1.3 suites
+    TLS13_CHACHA20_POLY1305_SHA256,
+    TLS13_AES_256_GCM_SHA384,
+    TLS13_AES_128_GCM_SHA256,
+];
+
+/// Implementation of the `rustls` certificate verification traits for libp2p.
+///
+/// Only TLS 1.3 is supported. TLS 1.2 should be disabled in the configuration of `rustls`.
+pub struct Libp2pCertificateVerifier {
+    /// The peer ID we intend to connect to
+    remote_peer_id: Option<PeerId>,
+}
+
+/// libp2p requires the following of X.509 server certificate chains:
+///
+/// - Exactly one certificate must be presented.
+/// - The certificate must be self-signed.
+/// - The certificate must have a valid libp2p extension that includes a
+///   signature of its public key.
+impl Libp2pCertificateVerifier {
+    pub fn new() -> Self {
+        Self {
+            remote_peer_id: None,
+        }
+    }
+    pub fn with_remote_peer_id(remote_peer_id: Option<PeerId>) -> Self {
+        Self { remote_peer_id }
+    }
+
+    /// Return the list of SignatureSchemes that this verifier will handle,
+    /// in `verify_tls12_signature` and `verify_tls13_signature` calls.
+    ///
+    /// This should be in priority order, with the most preferred first.
+    fn verification_schemes() -> Vec<SignatureScheme> {
+        vec![
+            // TODO SignatureScheme::ECDSA_NISTP521_SHA512 is not supported by `ring` yet
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            // TODO SignatureScheme::ED448 is not supported by `ring` yet
+            SignatureScheme::ED25519,
+            // In particular, RSA SHOULD NOT be used.
+        ]
+    }
+}
+
+impl ServerCertVerifier for Libp2pCertificateVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let peer_id = verify_presented_certs(end_entity, intermediates)?;
+
+        if let Some(ref remote_peer_id) = self.remote_peer_id {
+            // The public host key allows the peer to calculate the peer ID of the peer
+            // it is connecting to. Clients MUST verify that the peer ID derived from
+            // the certificate matches the peer ID they intended to connect to,
+            // and MUST abort the connection if there is a mismatch.
+            if remote_peer_id != &peer_id {
+                return Err(rustls::Error::PeerMisbehavedError(
+                    "Wrong peer ID in p2p extension".to_string(),
+                ));
+            }
+        }
+
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        unreachable!("`PROTOCOL_VERSIONS` only allows TLS 1.3")
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &Certificate,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(cert, dss.scheme, message, dss.signature())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        Self::verification_schemes()
+    }
+}
+
+/// libp2p requires the following of X.509 client certificate chains:
+///
+/// - Exactly one certificate must be presented. In particular, client
+///   authentication is mandatory in libp2p.
+/// - The certificate must be self-signed.
+/// - The certificate must have a valid libp2p extension that includes a
+///   signature of its public key.
+impl ClientCertVerifier for Libp2pCertificateVerifier {
+    fn offer_client_auth(&self) -> bool {
+        true
+    }
+
+    fn client_auth_root_subjects(&self) -> Option<DistinguishedNames> {
+        Some(vec![])
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
+        _now: std::time::SystemTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        verify_presented_certs(end_entity, intermediates)?;
+
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        unreachable!("`PROTOCOL_VERSIONS` only allows TLS 1.3")
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &Certificate,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(cert, dss.scheme, message, dss.signature())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        Self::verification_schemes()
+    }
+}
+
+/// When receiving the certificate chain, an endpoint
+/// MUST check these conditions and abort the connection attempt if
+/// (a) the presented certificate is not yet valid, OR
+/// (b) if it is expired.
+/// Endpoints MUST abort the connection attempt if more than one certificate is received,
+/// or if the certificate’s self-signature is not valid.
+fn verify_presented_certs(
+    end_entity: &Certificate,
+    intermediates: &[Certificate],
+) -> Result<PeerId, rustls::Error> {
+    if !intermediates.is_empty() {
+        return Err(rustls::Error::General(
+            "libp2p-tls requires exactly one certificate".into(),
+        ));
+    }
+
+    let cert = certificate::parse(end_entity)?;
+
+    Ok(cert.peer_id())
+}
+
+fn verify_tls13_signature(
+    cert: &Certificate,
+    signature_scheme: SignatureScheme,
+    message: &[u8],
+    signature: &[u8],
+) -> Result<HandshakeSignatureValid, rustls::Error> {
+    certificate::parse(cert)?.verify_signature(signature_scheme, message, signature)?;
+
+    Ok(HandshakeSignatureValid::assertion())
+}
+
+impl From<certificate::ParseError> for rustls::Error {
+    fn from(certificate::ParseError(e): certificate::ParseError) -> Self {
+        use webpki::Error::*;
+        match e {
+            BadDer => rustls::Error::InvalidCertificateEncoding,
+            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+        }
+    }
+}
+impl From<certificate::VerificationError> for rustls::Error {
+    fn from(certificate::VerificationError(e): certificate::VerificationError) -> Self {
+        use webpki::Error::*;
+        match e {
+            InvalidSignatureForPublicKey => rustls::Error::InvalidCertificateSignature,
+            UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
+                rustls::Error::InvalidCertificateSignatureType
+            }
+            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+        }
+    }
+}


### PR DESCRIPTION
- only ed25519 keys are supported
- no support for PeerIds that are based on protobufs
- remove support for RSA on the certificates