### PR TITLE
feat: rework client api to emit content

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -68,11 +68,11 @@ pub enum Event {
         size: usize,
     },
     /// Content is being received.
-    Received {
+    Receiving {
         /// The hash of the content we received.
         hash: bao::Hash,
         /// The actual data we are receiving.
-        data: Box<dyn AsyncRead + Unpin + Sync + Send + 'static>,
+        reader: Box<dyn AsyncRead + Unpin + Sync + Send + 'static>,
     },
     /// The transfer is done.
     Done(Stats),
@@ -167,7 +167,7 @@ pub fn run(hash: bao::Hash, opts: Options) -> impl Stream<Item = Result<Event>> 
                                 Ok::<(), anyhow::Error>(())
                             });
 
-                            yield Event::Received { hash, data: Box::new(a) };
+                            yield Event::Receiving { hash, reader: Box::new(a) };
 
                             t.await??;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use futures::Stream;
 use postcard::experimental::max_size::MaxSize;
 use s2n_quic::Connection;
 use s2n_quic::{client::Connect, Client};
-use tokio::io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tracing::debug;
 
 use crate::protocol::{read_lp_data, write_lp, Handshake, Request, Res, Response};
@@ -58,17 +58,27 @@ pub struct Stats {
     pub mbits: f64,
 }
 
+/// The events that are emitted while running a transfer.
 pub enum Event {
+    /// The connection to the server was established.
     Connected,
-    Requested { size: usize },
+    /// The server has the content.
+    Requested {
+        /// The size of the requested content.
+        size: usize,
+    },
+    /// Content is being received.
+    Received {
+        /// The hash of the content we received.
+        hash: bao::Hash,
+        /// The actual data we are receiving.
+        data: Box<dyn AsyncRead + Unpin + Sync + Send + 'static>,
+    },
+    /// The transfer is done.
     Done(Stats),
 }
 
-pub fn run<D: AsyncWrite + Unpin>(
-    hash: bao::Hash,
-    opts: Options,
-    mut dest: D,
-) -> impl Stream<Item = Result<Event>> {
+pub fn run(hash: bao::Hash, opts: Options) -> impl Stream<Item = Result<Event>> {
     async_stream::try_stream! {
         let now = Instant::now();
         let (_client, mut connection) = setup(opts).await?;
@@ -133,13 +143,17 @@ pub fn run<D: AsyncWrite + Unpin>(
                             if size != in_buffer.len() {
                                 Err(anyhow!("expected {} bytes, got {} bytes", size, in_buffer.len()))?;
                             }
-                            let mut decoder = bao::decode::Decoder::new_outboard(
-                                std::io::Cursor::new(&in_buffer[..]),
-                                outboard,
-                                &hash,
-                            );
+                            let (a, mut b) = tokio::io::duplex(1024);
 
-                            {
+                            let outboard = outboard.to_vec();
+                            let t = tokio::task::spawn(async move {
+                                let mut decoder = bao::decode::Decoder::new_outboard(
+                                    std::io::Cursor::new(&in_buffer[..]),
+                                    &*outboard,
+                                    &hash,
+                                );
+
+
                                 let mut buf = [0u8; 1024];
                                 loop {
                                     // TODO: avoid blocking
@@ -147,10 +161,15 @@ pub fn run<D: AsyncWrite + Unpin>(
                                     if read == 0 {
                                         break;
                                     }
-                                    dest.write_all(&buf[..read]).await?;
+                                    b.write_all(&buf[..read]).await?;
                                 }
-                                dest.flush().await?;
-                            }
+                                b.flush().await?;
+                                Ok::<(), anyhow::Error>(())
+                            });
+
+                            yield Event::Received { hash, data: Box::new(a) };
+
+                            t.await??;
 
                             // Shut down the stream
                             debug!("shutting down stream");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,15 +43,15 @@ mod tests {
         tokio::pin!(stream);
         while let Some(event) = stream.next().await {
             let event = event?;
-            if let Event::Received {
+            if let Event::Receiving {
                 hash: new_hash,
-                mut data,
+                mut reader,
             } = event
             {
                 assert_eq!(hash, new_hash);
                 let expect = tokio::fs::read(&path).await?;
                 let mut got = Vec::new();
-                data.read_to_end(&mut got).await?;
+                reader.read_to_end(&mut got).await?;
                 assert_eq!(expect, got);
             }
         }
@@ -101,14 +101,14 @@ mod tests {
             tokio::pin!(stream);
             while let Some(event) = stream.next().await {
                 let event = event?;
-                if let Event::Received {
+                if let Event::Receiving {
                     hash: new_hash,
-                    mut data,
+                    mut reader,
                 } = event
                 {
                     assert_eq!(hash, new_hash);
                     let mut got = Vec::new();
-                    data.read_to_end(&mut got).await?;
+                    reader.read_to_end(&mut got).await?;
                     assert_eq!(content, got);
                 }
             }
@@ -151,14 +151,14 @@ mod tests {
             tokio::pin!(stream);
             while let Some(event) = stream.next().await {
                 let event = event?;
-                if let Event::Received {
+                if let Event::Receiving {
                     hash: new_hash,
-                    mut data,
+                    mut reader,
                 } = event
                 {
                     assert_eq!(hash, new_hash);
                     let mut got = Vec::new();
-                    data.read_to_end(&mut got).await?;
+                    reader.read_to_end(&mut got).await?;
                     assert_eq!(content, got);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,12 @@ pub use tls::{PeerId, PeerIdError};
 mod tests {
     use std::{net::SocketAddr, path::PathBuf};
 
+    use crate::client::Event;
     use crate::tls::PeerId;
 
     use super::*;
     use anyhow::Result;
-    use futures::TryStreamExt;
+    use futures::StreamExt;
     use rand::RngCore;
     use testdir::testdir;
     use tokio::io::AsyncReadExt;
@@ -38,14 +39,22 @@ mod tests {
             addr,
             peer_id: Some(peer_id),
         };
-        let (mut source, sink) = tokio::io::duplex(1024);
-        let events: Vec<_> = client::run(hash, opts, sink).try_collect().await?;
-        assert_eq!(events.len(), 3);
-        let expect = tokio::fs::read(path).await?;
-        let mut got = Vec::new();
-        source.read_to_end(&mut got).await?;
-
-        assert_eq!(expect, got);
+        let stream = client::run(hash, opts);
+        tokio::pin!(stream);
+        while let Some(event) = stream.next().await {
+            let event = event?;
+            if let Event::Received {
+                hash: new_hash,
+                mut data,
+            } = event
+            {
+                assert_eq!(hash, new_hash);
+                let expect = tokio::fs::read(&path).await?;
+                let mut got = Vec::new();
+                data.read_to_end(&mut got).await?;
+                assert_eq!(expect, got);
+            }
+        }
 
         Ok(())
     }
@@ -88,13 +97,22 @@ mod tests {
                 addr,
                 peer_id: Some(peer_id),
             };
-            let (mut source, sink) = tokio::io::duplex(size);
-            let events: Vec<_> = client::run(hash, opts, sink).try_collect().await?;
-            assert_eq!(events.len(), 3);
-            let mut got = Vec::new();
-            source.read_to_end(&mut got).await?;
+            let stream = client::run(hash, opts);
+            tokio::pin!(stream);
+            while let Some(event) = stream.next().await {
+                let event = event?;
+                if let Event::Received {
+                    hash: new_hash,
+                    mut data,
+                } = event
+                {
+                    assert_eq!(hash, new_hash);
+                    let mut got = Vec::new();
+                    data.read_to_end(&mut got).await?;
+                    assert_eq!(content, got);
+                }
+            }
 
-            assert_eq!(content, got);
             server_task.abort();
             let _ = server_task.await;
         }
@@ -129,12 +147,21 @@ mod tests {
                 addr,
                 peer_id: Some(peer_id),
             };
-            let (mut source, sink) = tokio::io::duplex(1024);
-            let events: Vec<_> = client::run(hash, opts, sink).try_collect().await?;
-            assert_eq!(events.len(), 3);
-            let mut got = Vec::new();
-            source.read_to_end(&mut got).await?;
-            assert_eq!(content, got);
+            let stream = client::run(hash, opts);
+            tokio::pin!(stream);
+            while let Some(event) = stream.next().await {
+                let event = event?;
+                if let Event::Received {
+                    hash: new_hash,
+                    mut data,
+                } = event
+                {
+                    assert_eq!(hash, new_hash);
+                    let mut got = Vec::new();
+                    data.read_to_end(&mut got).await?;
+                    assert_eq!(content, got);
+                }
+            }
             Ok(())
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use clap::{Parser, Subcommand};
 use console::style;
 use futures::StreamExt;
@@ -71,14 +71,10 @@ async fn main() -> Result<()> {
 
             // Write file out
             let outpath = out.unwrap_or_else(|| hash.to_string().into());
-            let file = tokio::fs::File::create(outpath).await?;
-            let out = tokio::io::BufWriter::new(file);
 
             println!("{} Connecting ...", style("[1/3]").bold().dim());
             let pb = ProgressBar::hidden();
-            // wrap for progress bar
-            let mut wrapped_out = pb.wrap_async_write(out);
-            let stream = client::run(hash, opts, &mut wrapped_out);
+            let stream = client::run(hash, opts);
             tokio::pin!(stream);
             while let Some(event) = stream.next().await {
                 match event? {
@@ -95,6 +91,17 @@ async fn main() -> Result<()> {
                         );
                         pb.set_length(size as u64);
                         pb.set_draw_target(ProgressDrawTarget::stderr());
+                    }
+                    client::Event::Received {
+                        hash: new_hash,
+                        mut data,
+                    } => {
+                        ensure!(hash == new_hash, "invalid hash received");
+                        let file = tokio::fs::File::create(&outpath).await?;
+                        let out = tokio::io::BufWriter::new(file);
+                        // wrap for progress bar
+                        let mut wrapped_out = pb.wrap_async_write(out);
+                        tokio::io::copy(&mut data, &mut wrapped_out).await?;
                     }
                     client::Event::Done(stats) => {
                         pb.finish_and_clear();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,16 +92,16 @@ async fn main() -> Result<()> {
                         pb.set_length(size as u64);
                         pb.set_draw_target(ProgressDrawTarget::stderr());
                     }
-                    client::Event::Received {
+                    client::Event::Receiving {
                         hash: new_hash,
-                        mut data,
+                        mut reader,
                     } => {
                         ensure!(hash == new_hash, "invalid hash received");
                         let file = tokio::fs::File::create(&outpath).await?;
                         let out = tokio::io::BufWriter::new(file);
                         // wrap for progress bar
                         let mut wrapped_out = pb.wrap_async_write(out);
-                        tokio::io::copy(&mut data, &mut wrapped_out).await?;
+                        tokio::io::copy(&mut reader, &mut wrapped_out).await?;
                     }
                     client::Event::Done(stats) => {
                         pb.finish_and_clear();


### PR DESCRIPTION
This prepares the api to allow for multiple results to be emitted