### PR TITLE
feat: Add authentication token to protocol handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,9 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["dignifiedquire <me@dignifiedquire.com>"]
 repository = "https://github.com/n0-computer/sendme"
 
 [dependencies]
-anyhow = "1.0.68"
+anyhow = { version = "1.0.68", features = ["backtrace"] }
 async-stream = "0.3.3"
 bao = "0.12.1"
 blake3 = "1.3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,7 @@ mod tests {
         let token = server.auth_token();
 
         tokio::task::spawn(async move {
-            let opts = server::Options {
-                addr,
-                // token: Some(token),
-            };
+            let opts = server::Options { addr };
             server.run(opts).await.unwrap();
         });
 
@@ -97,10 +94,7 @@ mod tests {
             let token = server.auth_token();
 
             let server_task = tokio::task::spawn(async move {
-                let opts = server::Options {
-                    addr,
-                    // token: Some(token),
-                };
+                let opts = server::Options { addr };
                 server.run(opts).await.unwrap();
             });
 
@@ -146,10 +140,7 @@ mod tests {
         let token = server.auth_token();
 
         tokio::task::spawn(async move {
-            let opts = server::Options {
-                addr,
-                // token: Some(token),
-            };
+            let opts = server::Options { addr };
             server.run(opts).await.unwrap();
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 
 use anyhow::{anyhow, ensure, Context, Result};
 use clap::{Parser, Subcommand};
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
                 opts.addr = addr;
             }
             let token =
-                AuthToken::from_hex(&token).context("Wrong format for authentication token")?;
+                AuthToken::from_str(&token).context("Wrong format for authentication token")?;
 
             println!("{} Connecting ...", style("[1/3]").bold().dim());
             let pb = ProgressBar::hidden();
@@ -168,12 +168,12 @@ async fn main() -> Result<()> {
             }
             let mut provider = provider::Provider::new(db);
             if let Some(ref hex) = auth_token {
-                let auth_token = AuthToken::from_hex(hex)?;
+                let auth_token = AuthToken::from_str(hex)?;
                 provider.set_auth_token(auth_token);
             }
 
             println!("PeerID: {}", provider.peer_id());
-            println!("Auth token: {}", provider.auth_token().to_hex());
+            println!("Auth token: {}", provider.auth_token());
             provider.run(opts).await?;
 
             // Drop tempath to signal it can be destroyed

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
             let stream = client::run(hash, token, opts);
             tokio::pin!(stream);
             while let Some(event) = stream.next().await {
-                trace!("I HAZ EVENT from client: {:?}", event);
+                trace!("client event: {:?}", event);
                 match event? {
                     client::Event::Connected => {
                         println!("{} Requesting ...", style("[2/3]").bold().dim());
@@ -138,7 +138,6 @@ async fn main() -> Result<()> {
                     }
                 }
             }
-            println!("client connection closed");
         }
         Commands::Server { path, addr } => {
             let mut tmp_path = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,12 @@ enum Commands {
     #[clap(about = "Serve the data from the given path")]
     Provide {
         path: Option<PathBuf>,
-        #[clap(long, short)]
         /// Optional port, defaults to 127.0.01:4433.
+        #[clap(long, short)]
         addr: Option<SocketAddr>,
+        /// Auth token, defaults to random generated.
+        #[clap(long)]
+        auth_token: Option<String>,
     },
     /// Fetch some data
     #[clap(about = "Fetch the data from the hash")]
@@ -139,7 +142,11 @@ async fn main() -> Result<()> {
                 }
             }
         }
-        Commands::Provide { path, addr } => {
+        Commands::Provide {
+            path,
+            addr,
+            auth_token,
+        } => {
             let mut tmp_path = None;
 
             let sources = if let Some(path) = path {
@@ -160,6 +167,10 @@ async fn main() -> Result<()> {
                 opts.addr = addr;
             }
             let mut provider = provider::Provider::new(db);
+            if let Some(ref hex) = auth_token {
+                let auth_token = AuthToken::from_hex(hex)?;
+                provider.set_auth_token(auth_token);
+            }
 
             println!("PeerID: {}", provider.peer_id());
             println!("Auth token: {}", provider.auth_token().to_hex());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Context, Result};
 use bytes::BytesMut;
 use postcard::experimental::max_size::MaxSize;
 use serde::{Deserialize, Serialize};
@@ -149,8 +149,8 @@ impl AuthToken {
     ///
     /// If the string is not long enough or not hex an error is returned.
     pub fn from_hex(hex: &str) -> Result<Self> {
-        ensure!(hex.len() >= 64);
-        let decoded = hex::decode(&hex[..64])?;
+        ensure!(hex.len() >= 64, "invalid length for hex AuthToken");
+        let decoded = hex::decode(&hex[..64]).context("invalid hex for AuthToken")?;
         let bytes = decoded.try_into().expect("slice is right length");
         Ok(Self { bytes })
     }
@@ -171,12 +171,12 @@ mod tests {
     #[test]
     fn test_auth_token_hex() {
         let token = AuthToken::generate();
-
         let hex = token.to_hex();
         println!("token: {hex}");
-
         let decoded = AuthToken::from_hex(&hex).unwrap();
-
         assert_eq!(decoded, token);
+
+        let token = AuthToken::from_hex("not-hex");
+        assert!(token.is_err());
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -56,6 +56,10 @@ impl Provider {
         self.auth_token
     }
 
+    pub fn set_auth_token(&mut self, auth_token: AuthToken) {
+        self.auth_token = auth_token;
+    }
+
     pub async fn run(&mut self, opts: Options) -> Result<()> {
         let server_config = tls::make_server_config(&self.keypair)?;
         let tls = s2n_quic::provider::tls::rustls::Server::from(server_config);

--- a/src/server.rs
+++ b/src/server.rs
@@ -70,7 +70,6 @@ impl Server {
             .with_limits(limits)?
             .start()
             .map_err(|e| anyhow!("{:?}", e))?;
-        // let token = opts.token.unwrap_or_else(AuthToken::generate);
         let token = self.auth_token;
         debug!("\nlistening at: {:#?}", server.local_addr().unwrap());
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,7 +9,7 @@ use s2n_quic::Server as QuicServer;
 use tokio::io::AsyncWrite;
 use tracing::{debug, warn};
 
-use crate::protocol::{read_lp, write_lp, Handshake, Request, Res, Response, VERSION};
+use crate::protocol::{read_lp, write_lp, AuthToken, Handshake, Request, Res, Response, VERSION};
 use crate::tls::{self, Keypair, PeerId};
 
 #[derive(Clone, Debug)]
@@ -33,17 +33,27 @@ pub type Database = Arc<HashMap<bao::Hash, Data>>;
 
 pub struct Server {
     keypair: Keypair,
+    auth_token: AuthToken,
     db: Database,
 }
 
 impl Server {
     pub fn new(db: Database) -> Self {
         let keypair = Keypair::generate();
-        Server { keypair, db }
+        let auth_token = AuthToken::generate();
+        Server {
+            keypair,
+            db,
+            auth_token,
+        }
     }
 
     pub fn peer_id(&self) -> PeerId {
         self.keypair.public().into()
+    }
+
+    pub fn auth_token(&self) -> AuthToken {
+        self.auth_token
     }
 
     pub async fn run(&mut self, opts: Options) -> Result<()> {
@@ -60,7 +70,8 @@ impl Server {
             .with_limits(limits)?
             .start()
             .map_err(|e| anyhow!("{:?}", e))?;
-
+        // let token = opts.token.unwrap_or_else(AuthToken::generate);
+        let token = self.auth_token;
         debug!("\nlistening at: {:#?}", server.local_addr().unwrap());
 
         while let Some(mut connection) = server.accept().await {
@@ -71,7 +82,7 @@ impl Server {
                 while let Ok(Some(stream)) = connection.accept_bidirectional_stream().await {
                     let db = db.clone();
                     tokio::spawn(async move {
-                        if let Err(err) = handle_stream(db, stream).await {
+                        if let Err(err) = handle_stream(db, token, stream).await {
                             warn!("error: {:#?}", err);
                         }
                         debug!("disconnected");
@@ -86,6 +97,7 @@ impl Server {
 
 async fn handle_stream(
     db: Arc<HashMap<bao::Hash, Data>>,
+    token: AuthToken,
     stream: BidirectionalStream,
 ) -> Result<()> {
     debug!("stream opened from {:?}", stream.connection().remote_addr());
@@ -102,6 +114,7 @@ async fn handle_stream(
             VERSION,
             handshake.version
         );
+        ensure!(handshake.token == token, "AuthToken mismatch");
         let _ = in_buffer.split_to(size);
     } else {
         bail!("no valid handshake received");

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -39,6 +39,15 @@ impl Keypair {
 }
 
 // TODO: probably needs a version field
+/// An identifier for networked peers.
+///
+/// Each network node has a cryptographic identifier which can be used to make sure you are
+/// connecting to the right peer.
+///
+/// # `Display` and `FromStr`
+///
+/// The [`PeerId`] implements both `Display` and `FromStr` which can be used to
+/// (de)serialise to human-readable and relatively safely transferrable strings.
 #[derive(Clone, PartialEq, Copy)]
 pub struct PeerId(PublicKey);
 
@@ -54,6 +63,9 @@ impl Debug for PeerId {
     }
 }
 
+/// Serialises the [`PeerId`] to hex.
+///
+/// [`FromStr`] is capable of deserialising this format.
 impl Display for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", hex::encode(self.0.as_bytes()))
@@ -68,6 +80,9 @@ pub enum PeerIdError {
     Key(#[from] ed25519_dalek::SignatureError),
 }
 
+/// Deserialises the [`PeerId`] from it's hex encoding.
+///
+/// [`Display`] is capable of serialising this format.
 impl FromStr for PeerId {
     type Err = PeerIdError;
 


### PR DESCRIPTION
This ensures that only clients which have the token can connect to the
server and retrieve the file.

# status

This needs a little cleanup but is basically ready.  Pushing this now
so it can already have some feedback, after I've been very delayed due
to entirely self-inflicted needless bugs that I introduced.