### PR TITLE
feat: Create a Builder for the Provider

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,13 +92,7 @@ mod tests {
         let expect_name = Some(filename.to_string());
 
         let (db, hash) = provider::create_db(vec![provider::DataSource::File(path)]).await?;
-        let mut provider = provider::Provider::builder().database(db).build()?;
-        let peer_id = provider.peer_id();
-        let token = provider.auth_token();
-
-        tokio::task::spawn(async move {
-            provider.run(provider::Options { addr }).await.unwrap();
-        });
+        let provider = provider::Provider::builder(db).bind_addr(addr).spawn()?;
 
         async fn run_client(
             hash: bao::Hash,
@@ -137,11 +131,11 @@ mod tests {
         for _i in 0..3 {
             tasks.push(tokio::task::spawn(run_client(
                 hash,
-                token,
+                provider.auth_token(),
                 expect_hash,
                 expect_name.clone(),
                 addr,
-                peer_id,
+                provider.peer_id(),
                 content.to_vec(),
             )));
         }
@@ -201,19 +195,13 @@ mod tests {
         let (db, collection_hash) = provider::create_db(files).await?;
 
         let addr = format!("127.0.0.1:{port}").parse().unwrap();
-        let mut provider = provider::Provider::builder().database(db).build()?;
-        let peer_id = provider.peer_id();
-        let token = provider.auth_token();
-
-        let provider_task = tokio::task::spawn(async move {
-            provider.run(provider::Options { addr }).await.unwrap();
-        });
+        let provider = provider::Provider::builder(db).bind_addr(addr).spawn()?;
 
         let opts = get::Options {
             addr,
-            peer_id: Some(peer_id),
+            peer_id: Some(provider.peer_id()),
         };
-        let stream = get::run(collection_hash, token, opts);
+        let stream = get::run(collection_hash, provider.auth_token(), opts);
         tokio::pin!(stream);
 
         let mut i = 0;
@@ -236,8 +224,8 @@ mod tests {
             }
         }
 
-        provider_task.abort();
-        let _ = provider_task.await;
+        provider.abort();
+        let _ = provider.join().await;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,19 +162,19 @@ async fn main() -> Result<()> {
             };
 
             let db = provider::create_db(sources).await?;
-            let mut opts = provider::Options::default();
+            let mut builder = provider::Provider::builder(db);
             if let Some(addr) = addr {
-                opts.addr = addr;
+                builder = builder.bind_addr(addr);
             }
-            let mut provider = provider::Provider::new(db);
             if let Some(ref hex) = auth_token {
                 let auth_token = AuthToken::from_str(hex)?;
-                provider.set_auth_token(auth_token);
+                builder = builder.auth_token(auth_token);
             }
+            let provider = builder.spawn()?;
 
             println!("PeerID: {}", provider.peer_id());
             println!("Auth token: {}", provider.auth_token());
-            provider.run(opts).await?;
+            provider.join().await?;
 
             // Drop tempath to signal it can be destroyed
             drop(tmp_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,8 +168,7 @@ async fn main() -> Result<()> {
             };
 
             let db = provider::create_db(sources).await?;
-            let mut builder = provider::Provider::builder(db);
-            // TODO: add keypair
+            let mut builder = provider::Provider::builder(db).keypair(keypair);
             if let Some(addr) = addr {
                 builder = builder.bind_addr(addr);
             }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -35,7 +35,7 @@ pub struct Builder {
 
 impl Builder {
     /// Creates a new builder for [`Provider`] using the given [`Database`].
-    pub fn new(db: Database) -> Self {
+    pub fn with_db(db: Database) -> Self {
         Self {
             bind_addr: "127.0.0.1:4433".parse().unwrap(),
             keypair: Keypair::generate(),
@@ -91,7 +91,6 @@ impl Builder {
             listen_addr,
             keypair: self.keypair,
             auth_token: self.auth_token,
-            // db: self.db,
             task,
         })
     }
@@ -129,7 +128,6 @@ pub struct Provider {
     listen_addr: SocketAddr,
     keypair: Keypair,
     auth_token: AuthToken,
-    // db: Database,
     task: JoinHandle<()>,
 }
 
@@ -138,7 +136,7 @@ impl Provider {
     ///
     /// Once the done with the builder call [`Builder::spawn`] to create the provider.
     pub fn builder(db: Database) -> Builder {
-        Builder::new(db)
+        Builder::with_db(db)
     }
 
     /// Returns the address on which the server is listening for connections.


### PR DESCRIPTION
This is a nicer API to create a builder.  Crucially it can give all
the information to connect to a provider once it is started.
Something that wasn't quite possible before.

This is part of n0-computer/iroh#749 but is probably clearer split off first.