### PR TITLE
Change data encoding from outboard then data to bao slice encoding

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -158,6 +158,8 @@ pub fn run(hash: bao::Hash, token: AuthToken, opts: Options) -> impl Stream<Item
                                 Err(anyhow!("size too large: {} > {}", size, MAX_DATA_SIZE))?;
                             }
 
+                            let mut reader = AsyncReadExt::chain(std::io::Cursor::new(in_buffer), reader);
+
                             // TODO: avoid buffering
 
                             // remove response buffered data
@@ -176,9 +178,6 @@ pub fn run(hash: bao::Hash, token: AuthToken, opts: Options) -> impl Stream<Item
                             // TODO: avoid copy
                             let outboard = outboard.to_vec();
                             println!("got outboard of size {}", outboard.len());
-                            reader = tokio::task::spawn_blocking(|| {
-                                reader
-                            }).await?;
                             let t = tokio::task::spawn(async move {
                                 let mut decoder = bao::decode::Decoder::new(
                                     std::io::Cursor::new(&buffer),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -45,19 +45,13 @@ pub struct Response {
 pub enum Res {
     NotFound,
     // If found, a stream of bao data is sent as next message.
-    Found {
-        /// The size of the coming data in bytes, raw content size.
-        size: usize,
-    },
+    Found,
 }
 
 impl Res {
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        match self {
-            Self::Found { size: _ } => 0,
-            _ => 0,
-        }
+        0
     }
 }
 
@@ -130,6 +124,17 @@ async fn read_prefix<R: AsyncRead + futures::io::AsyncRead + Unpin>(
     };
 
     Ok(size)
+}
+
+pub async fn ensure_buffer_size<R: AsyncRead + futures::io::AsyncRead + Unpin>(
+    mut reader: R,
+    buffer: &mut BytesMut,
+    size: usize,
+) -> Result<()> {
+    while buffer.len() < size {
+        reader.read_buf(buffer).await?;
+    }
+    Ok(())
 }
 
 /// A token used to authenticate a handshake.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -36,28 +36,26 @@ pub struct Request {
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
-pub struct Response<'a> {
+pub struct Response {
     pub id: u64,
-    #[serde(borrow)]
-    pub data: Res<'a>,
+    pub data: Res,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
-pub enum Res<'a> {
+pub enum Res {
     NotFound,
     // If found, a stream of bao data is sent as next message.
     Found {
         /// The size of the coming data in bytes, raw content size.
         size: usize,
-        outboard: &'a [u8],
     },
 }
 
-impl Res<'_> {
+impl Res {
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         match self {
-            Self::Found { outboard, .. } => outboard.len(),
+            Self::Found { size: _ } => 0,
             _ => 0,
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -48,13 +48,6 @@ pub enum Res {
     Found,
 }
 
-impl Res {
-    #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
-        0
-    }
-}
-
 /// Write the given data to the provider sink, with a unsigned varint length prefix.
 pub async fn write_lp<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> Result<()> {
     ensure!(

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -139,13 +139,8 @@ async fn handle_stream(
                         size,
                     }) => {
                         debug!("found {}", name.to_hex());
-                        write_response(
-                            &mut writer,
-                            &mut out_buffer,
-                            request.id,
-                            Res::Found { size: *size },
-                        )
-                        .await?;
+                        write_response(&mut writer, &mut out_buffer, request.id, Res::Found)
+                            .await?;
 
                         debug!("writing data");
                         let path = path.clone();

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -238,8 +238,8 @@ async fn write_response<W: AsyncWrite + Unpin>(
 ) -> Result<()> {
     let response = Response { id, data: res };
 
-    if buffer.len() < 20 + response.data.len() {
-        buffer.resize(20 + response.data.len(), 0u8);
+    if buffer.len() < 20 {
+        buffer.resize(20, 0u8);
     }
     let used = postcard::to_slice(&response, buffer)?;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -143,16 +143,11 @@ async fn handle_stream(
                             &mut writer,
                             &mut out_buffer,
                             request.id,
-                            Res::Found {
-                                size: *size,
-                                outboard: &[],
-                            },
+                            Res::Found { size: *size },
                         )
                         .await?;
 
                         debug!("writing data");
-                        let file = tokio::fs::File::open(&path).await?;
-                        let mut reader = tokio::io::BufReader::new(file);
                         let path = path.clone();
                         let outboard = outboard.clone();
                         let size = *size;
@@ -174,7 +169,6 @@ async fn handle_stream(
                         })
                         .await
                         .unwrap()?;
-                        tokio::io::copy(&mut reader, &mut writer).await?;
                     }
                     None => {
                         debug!("not found {}", name.to_hex());
@@ -245,7 +239,7 @@ async fn write_response<W: AsyncWrite + Unpin>(
     mut writer: W,
     buffer: &mut BytesMut,
     id: u64,
-    res: Res<'_>,
+    res: Res,
 ) -> Result<()> {
     let response = Response { id, data: res };
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -156,6 +156,9 @@ async fn handle_stream(
                         let path = path.clone();
                         let outboard = outboard.clone();
                         let size = *size;
+                        // need to thread the writer though the spawn_blocking, since
+                        // taking a reference does not work. spawn_blocking requires
+                        // 'static lifetime.
                         writer = tokio::task::spawn_blocking(move || {
                             let file_reader = std::fs::File::open(&path)?;
                             let outboard_reader = std::io::Cursor::new(outboard);
@@ -166,8 +169,7 @@ async fn handle_stream(
                                 0,
                                 size as u64,
                             );
-                            let copied = std::io::copy(&mut slice_extractor, &mut wrapper)?;
-                            println!("copied {} bytes", copied);
+                            let _copied = std::io::copy(&mut slice_extractor, &mut wrapper)?;
                             std::io::Result::Ok(writer)
                         })
                         .await


### PR DESCRIPTION
Quite curious about the perf of this brute force baseline version that just uses the SyncIoBridge.

Note that this will heavily conflict with https://github.com/n0-computer/sendme/pull/48 . So it will probably have to be rewritten completely.