### PR TITLE
refactor: compute outboard without reading the entire file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,7 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
+ "is-terminal",
  "postcard",
  "rand 0.7.3",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,10 +142,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bitflags"
@@ -303,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
 name = "const_format"
 version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +359,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -389,7 +419,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
+ "const-oid",
  "der_derive",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -434,6 +467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -447,6 +481,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
 ]
 
 [[package]]
@@ -468,7 +514,26 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest 0.10.6",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
  "zeroize",
 ]
 
@@ -506,6 +571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -642,6 +717,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "hash_hasher"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +768,15 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
+]
 
 [[package]]
 name = "indicatif"
@@ -756,6 +851,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -886,12 +984,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -975,6 +1101,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1037,6 +1194,28 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1241,6 +1420,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1443,27 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rsa"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
+dependencies = [
+ "byteorder",
+ "digest 0.10.6",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "smallvec",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1447,6 +1658,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1703,7 @@ dependencies = [
  "rustls",
  "s2n-quic",
  "serde",
+ "ssh-key",
  "tempfile",
  "testdir",
  "thiserror",
@@ -1488,6 +1714,7 @@ dependencies = [
  "unsigned-varint",
  "webpki",
  "x509-parser",
+ "zeroize",
 ]
 
 [[package]]
@@ -1535,6 +1762,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1795,10 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "siphasher"
@@ -1594,6 +1836,45 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19cfdc32e0199062113edf41f344fbf784b8205a94600233c84eb838f45191e1"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288d8f5562af5a3be4bda308dd374b2c807b940ac370b5efa1c99311da91d9a1"
+dependencies = [
+ "ed25519-dalek",
+ "p256",
+ "p384",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2 0.10.6",
+ "signature",
+ "ssh-encoding",
+ "zeroize",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ring = "0.16.20"
 rustls = { version = "0.20.8", default-features = false, features = ["dangerous_configuration"] }
 s2n-quic = { version = "1.14.0", default-features = false, features = [ "provider-tls-rustls", "provider-address-token-default" ] }
 serde = { version = "1.0.152", features = ["derive"] }
+ssh-key = { version = "0.5.1", features = ["ed25519", "std", "rand_core"] }
 tempfile = "3.3.0"
 thiserror = "1.0.38"
 tokio = { version = "1.24.1", features = ["full"] }
@@ -36,6 +37,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 unsigned-varint = { version = "0.7.1", features = ["futures"] }
 webpki = "0.22.0"
 x509-parser = "0.14.0"
+zeroize = "1.5.7"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ed25519-dalek = "1.0.1"
 futures = "0.3.25"
 hex = "0.4.3"
 indicatif = { version = "0.17.2", features = ["tokio"] }
+is-terminal = "0.4.2"
 postcard = { version = "1.0.2", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"
 rcgen = "0.10.0"

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -1,0 +1,118 @@
+use std::io::Read;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Collection {
+    ///
+    /// The name of this collection
+    pub(crate) name: String,
+    /// Links to the blobs in this collection
+    pub(crate) blobs: Vec<Blob>,
+    /// The total size of the raw_data referred to by all links
+    pub(crate) total_blobs_size: u64,
+}
+
+impl Collection {
+    pub async fn decode_from(data: Bytes, outboard: &[u8], hash: bao::Hash) -> Result<Self> {
+        // TODO: avoid copy
+        let outboard = outboard.to_vec();
+        // verify that the content of data matches the expected hash
+        let mut decoder =
+            bao::decode::Decoder::new_outboard(std::io::Cursor::new(&data[..]), &*outboard, &hash);
+
+        let mut buf = [0u8; 1024];
+        loop {
+            // TODO: write & use an `async decoder`
+            let read = decoder
+                .read(&mut buf)
+                .context("hash of Collection data does not match")?;
+            if read == 0 {
+                break;
+            }
+        }
+        let c: Collection =
+            postcard::from_bytes(&data).context("failed to serialize Collection data")?;
+        Ok(c)
+    }
+
+    pub fn total_blobs_size(&self) -> u64 {
+        self.total_blobs_size
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn total_entries(&self) -> u64 {
+        self.blobs.len() as u64
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Blob {
+    /// The name of this blob of data
+    pub(crate) name: String,
+    /// The hash of the blob of data
+    #[serde(with = "hash_serde")]
+    pub(crate) hash: bao::Hash,
+}
+
+mod hash_serde {
+    use serde::{de, Deserializer, Serializer};
+
+    pub fn serialize<S>(h: &bao::Hash, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_bytes(h.as_bytes())
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<bao::Hash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HashVisitor;
+
+        impl<'de> de::Visitor<'de> for HashVisitor {
+            type Value = bao::Hash;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an array of 32 bytes containing hash data")
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let b: [u8; 32] = v.try_into().map_err(E::custom)?;
+                Ok(bao::Hash::from(b))
+            }
+        }
+
+        d.deserialize_bytes(HashVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_blob() {
+        let b = Blob {
+            name: "test".to_string(),
+            hash: bao::Hash::from_hex(
+                "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d",
+            )
+            .unwrap(),
+        };
+
+        let mut buf = bytes::BytesMut::zeroed(1024);
+        postcard::to_slice(&b, &mut buf).unwrap();
+        let deserialize_b: Blob = postcard::from_bytes(&buf).unwrap();
+        assert_eq!(b, deserialize_b);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod blobs;
 pub mod get;
 pub mod protocol;
 pub mod provider;
@@ -23,49 +24,30 @@ mod tests {
 
     #[tokio::test]
     async fn basics() -> Result<()> {
-        let dir: PathBuf = testdir!();
-        let path = dir.join("hello_world");
-        tokio::fs::write(&path, "hello world!").await?;
-        let db = provider::create_db(vec![provider::DataSource::File(path.clone())]).await?;
-        let hash = *db.iter().next().unwrap().0;
-        let addr = "127.0.0.1:4443".parse().unwrap();
-        let mut provider = provider::Provider::builder().database(db).build()?;
-        let peer_id = provider.peer_id();
-        let token = provider.auth_token();
+        let port: u16 = 4443;
+        transfer_data(
+            vec![("hello_world", "hello world!".as_bytes().to_vec())],
+            port,
+        )
+        .await
+    }
 
-        tokio::task::spawn(async move {
-            provider.run(provider::Options { addr }).await.unwrap();
-        });
-
-        let opts = get::Options {
-            addr,
-            peer_id: Some(peer_id),
-        };
-        let stream = get::run(hash, token, opts);
-        tokio::pin!(stream);
-        while let Some(event) = stream.next().await {
-            let event = event?;
-            if let Event::Receiving {
-                hash: new_hash,
-                mut reader,
-            } = event
-            {
-                assert_eq!(hash, new_hash);
-                let expect = tokio::fs::read(&path).await?;
-                let mut got = Vec::new();
-                reader.read_to_end(&mut got).await?;
-                assert_eq!(expect, got);
-            }
-        }
-
-        Ok(())
+    #[tokio::test]
+    async fn multi_file() -> Result<()> {
+        let file_opts = vec![
+            ("1", 10),
+            ("2", 1024),
+            ("3", 1024 * 1024),
+            // overkill, but it works! Just annoying to wait for
+            // ("4", 1024 * 1024 * 90),
+        ];
+        transfer_random_data(file_opts, 4446).await
     }
 
     #[tokio::test]
     async fn sizes() -> Result<()> {
-        let addr = "127.0.0.1:4445".parse().unwrap();
-
         let sizes = [
+            0,
             10,
             100,
             1024,
@@ -74,65 +56,42 @@ mod tests {
             1024 * 1024,
             1024 * 1024 + 10,
         ];
+        let port: u16 = 4445;
 
         for size in sizes {
-            println!("testing {size} bytes");
-
-            let dir: PathBuf = testdir!();
-            let path = dir.join("hello_world");
-
-            let mut content = vec![0u8; size];
-            rand::thread_rng().fill_bytes(&mut content);
-
-            tokio::fs::write(&path, &content).await?;
-
-            let db = provider::create_db(vec![provider::DataSource::File(path)]).await?;
-            let hash = *db.iter().next().unwrap().0;
-            let mut provider = provider::Provider::builder().database(db).build()?;
-            let peer_id = provider.peer_id();
-            let token = provider.auth_token();
-
-            let provider_task = tokio::task::spawn(async move {
-                provider.run(provider::Options { addr }).await.unwrap();
-            });
-
-            let opts = get::Options {
-                addr,
-                peer_id: Some(peer_id),
-            };
-            let stream = get::run(hash, token, opts);
-            tokio::pin!(stream);
-            while let Some(event) = stream.next().await {
-                let event = event?;
-                if let Event::Receiving {
-                    hash: new_hash,
-                    mut reader,
-                } = event
-                {
-                    assert_eq!(hash, new_hash);
-                    let mut got = Vec::new();
-                    reader.read_to_end(&mut got).await?;
-                    assert_eq!(content, got);
-                }
-            }
-
-            provider_task.abort();
-            let _ = provider_task.await;
+            transfer_random_data(vec![("hello_world", size)], port).await?;
         }
 
         Ok(())
     }
 
+    #[tokio::test]
+    async fn empty_files() -> Result<()> {
+        // try to transfer as many files as possible without hitting a limit
+        // booo 400 is too small :(
+        let num_files = 400;
+        let mut file_opts = Vec::new();
+        for i in 0..num_files {
+            file_opts.push((i.to_string(), 0));
+        }
+        transfer_random_data(file_opts, 4447).await
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn multiple_clients() -> Result<()> {
         let dir: PathBuf = testdir!();
-        let path = dir.join("hello_world");
+        let filename = "hello_world";
+        let path = dir.join(filename);
         let content = b"hello world!";
         let addr = "127.0.0.1:4444".parse().unwrap();
 
         tokio::fs::write(&path, content).await?;
-        let db = provider::create_db(vec![provider::DataSource::File(path)]).await?;
-        let hash = *db.iter().next().unwrap().0;
+        // hash of the transfer file
+        let data = tokio::fs::read(&path).await?;
+        let (_, expect_hash) = bao::encode::outboard(&data);
+        let expect_name = Some(filename.to_string());
+
+        let (db, hash) = provider::create_db(vec![provider::DataSource::File(path)]).await?;
         let mut provider = provider::Provider::builder().database(db).build()?;
         let peer_id = provider.peer_id();
         let token = provider.auth_token();
@@ -144,6 +103,8 @@ mod tests {
         async fn run_client(
             hash: bao::Hash,
             token: AuthToken,
+            file_hash: bao::Hash,
+            name: Option<String>,
             addr: SocketAddr,
             peer_id: PeerId,
             content: Vec<u8>,
@@ -157,14 +118,16 @@ mod tests {
             while let Some(event) = stream.next().await {
                 let event = event?;
                 if let Event::Receiving {
-                    hash: new_hash,
+                    hash: got_hash,
                     mut reader,
+                    name: got_name,
                 } = event
                 {
-                    assert_eq!(hash, new_hash);
+                    assert_eq!(file_hash, got_hash);
                     let mut got = Vec::new();
                     reader.read_to_end(&mut got).await?;
                     assert_eq!(content, got);
+                    assert_eq!(name, got_name);
                 }
             }
             Ok(())
@@ -175,6 +138,8 @@ mod tests {
             tasks.push(tokio::task::spawn(run_client(
                 hash,
                 token,
+                expect_hash,
+                expect_name.clone(),
                 addr,
                 peer_id,
                 content.to_vec(),
@@ -185,6 +150,94 @@ mod tests {
             task.await??;
         }
 
+        Ok(())
+    }
+
+    // Run the test creating random data for each blob, using the size specified by the file
+    // options
+    // TODO: use random ports
+    async fn transfer_random_data<S>(file_opts: Vec<(S, usize)>, port: u16) -> Result<()>
+    where
+        S: Into<String> + std::fmt::Debug + std::cmp::PartialEq,
+    {
+        let file_opts = file_opts
+            .into_iter()
+            .map(|(name, size)| {
+                let mut content = vec![0u8; size];
+                rand::thread_rng().fill_bytes(&mut content);
+                (name, content)
+            })
+            .collect();
+        transfer_data(file_opts, port).await
+    }
+
+    // Run the test for a vec of filenames and blob data
+    // TODO: use random ports
+    async fn transfer_data<S>(file_opts: Vec<(S, Vec<u8>)>, port: u16) -> Result<()>
+    where
+        S: Into<String> + std::fmt::Debug + std::cmp::PartialEq,
+    {
+        let dir: PathBuf = testdir!();
+
+        // create and save files
+        let mut files = Vec::new();
+        let mut expects = Vec::new();
+
+        for opt in file_opts.into_iter() {
+            let (name, data) = opt;
+
+            let name = name.into();
+            let path = dir.join(name.clone());
+            // get expected hash of file
+            let (_, hash) = bao::encode::outboard(&data);
+
+            tokio::fs::write(&path, data).await?;
+            files.push(provider::DataSource::File(path.clone()));
+
+            // keep track of expected values
+            expects.push((Some(name), path, hash));
+        }
+
+        let (db, collection_hash) = provider::create_db(files).await?;
+
+        let addr = format!("127.0.0.1:{port}").parse().unwrap();
+        let mut provider = provider::Provider::builder().database(db).build()?;
+        let peer_id = provider.peer_id();
+        let token = provider.auth_token();
+
+        let provider_task = tokio::task::spawn(async move {
+            provider.run(provider::Options { addr }).await.unwrap();
+        });
+
+        let opts = get::Options {
+            addr,
+            peer_id: Some(peer_id),
+        };
+        let stream = get::run(collection_hash, token, opts);
+        tokio::pin!(stream);
+
+        let mut i = 0;
+        while let Some(event) = stream.next().await {
+            let event = event?;
+            if let Event::Receiving {
+                hash: got_hash,
+                mut reader,
+                name: got_name,
+            } = event
+            {
+                let (expect_name, path, expect_hash) = expects.get(i).unwrap();
+                assert_eq!(*expect_hash, got_hash);
+                let expect = tokio::fs::read(&path).await?;
+                let mut got = Vec::new();
+                reader.read_to_end(&mut got).await?;
+                assert_eq!(expect, got);
+                assert_eq!(*expect_name, got_name);
+                i += 1;
+            }
+        }
+
+        provider_task.abort();
+        let _ = provider_task.await;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod tests {
         let db = provider::create_db(vec![provider::DataSource::File(path.clone())]).await?;
         let hash = *db.iter().next().unwrap().0;
         let addr = "127.0.0.1:4443".parse().unwrap();
-        let mut provider = provider::Provider::new(db);
+        let mut provider = provider::Provider::builder().database(db).build()?;
         let peer_id = provider.peer_id();
         let token = provider.auth_token();
 
@@ -88,7 +88,7 @@ mod tests {
 
             let db = provider::create_db(vec![provider::DataSource::File(path)]).await?;
             let hash = *db.iter().next().unwrap().0;
-            let mut provider = provider::Provider::new(db);
+            let mut provider = provider::Provider::builder().database(db).build()?;
             let peer_id = provider.peer_id();
             let token = provider.auth_token();
 
@@ -133,7 +133,7 @@ mod tests {
         tokio::fs::write(&path, content).await?;
         let db = provider::create_db(vec![provider::DataSource::File(path)]).await?;
         let hash = *db.iter().next().unwrap().0;
-        let mut provider = provider::Provider::new(db);
+        let mut provider = provider::Provider::builder().database(db).build()?;
         let peer_id = provider.peer_id();
         let token = provider.auth_token();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod provider;
 
 mod tls;
 
-pub use tls::{PeerId, PeerIdError};
+pub use tls::{Keypair, PeerId, PeerIdError, PublicKey, SecretKey, Signature};
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,11 +166,12 @@ async fn main() -> Result<()> {
             if let Some(addr) = addr {
                 opts.addr = addr;
             }
-            let mut provider = provider::Provider::new(db);
+            let mut provider_builder = provider::Provider::builder().database(db);
             if let Some(ref hex) = auth_token {
                 let auth_token = AuthToken::from_str(hex)?;
-                provider.set_auth_token(auth_token);
+                provider_builder = provider_builder.auth_token(auth_token);
             }
+            let mut provider = provider_builder.build()?;
 
             println!("PeerID: {}", provider.peer_id());
             println!("Auth token: {}", provider.auth_token());

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use sendme::protocol::AuthToken;
 use tracing::trace;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use sendme::{get, provider, PeerId};
+use sendme::{get, provider, Keypair, PeerId};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(version, about, long_about = None)]
@@ -32,6 +32,9 @@ enum Commands {
         /// Auth token, defaults to random generated.
         #[clap(long)]
         auth_token: Option<String>,
+        /// If this path is provided and it exists, the private key ist read from this file and used, if it does not exist the private key will be persisted to this location.
+        #[clap(long)]
+        key: Option<PathBuf>,
     },
     /// Fetch some data
     #[clap(about = "Fetch the data from the hash")]
@@ -146,7 +149,10 @@ async fn main() -> Result<()> {
             path,
             addr,
             auth_token,
+            key,
         } => {
+            let keypair = get_keypair(key).await?;
+
             let mut tmp_path = None;
 
             let sources = if let Some(path) = path {
@@ -166,7 +172,7 @@ async fn main() -> Result<()> {
             if let Some(addr) = addr {
                 opts.addr = addr;
             }
-            let mut provider_builder = provider::Provider::builder().database(db);
+            let mut provider_builder = provider::Provider::builder().database(db).keypair(keypair);
             if let Some(ref hex) = auth_token {
                 let auth_token = AuthToken::from_str(hex)?;
                 provider_builder = provider_builder.auth_token(auth_token);
@@ -183,4 +189,25 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn get_keypair(key: Option<PathBuf>) -> Result<Keypair> {
+    match key {
+        Some(key_path) => {
+            if key_path.exists() {
+                let keystr = tokio::fs::read(key_path).await?;
+                let keypair = Keypair::try_from_openssh(keystr)?;
+                Ok(keypair)
+            } else {
+                let keypair = Keypair::generate();
+                let ser_key = keypair.to_openssh()?;
+                tokio::fs::write(key_path, ser_key).await?;
+                Ok(keypair)
+            }
+        }
+        None => {
+            // No path provided, just generate one
+            Ok(Keypair::generate())
+        }
+    }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use s2n_quic::stream::BidirectionalStream;
 use s2n_quic::Server as QuicServer;
@@ -282,6 +282,42 @@ pub enum DataSource {
     File(PathBuf),
 }
 
+/// Synchronously compute the outboard of a file, and return hash and outboard.
+///
+/// It is assumed that the file is not modified while this is running.
+///
+/// If it is modified while or after this is running, the outboard will be
+/// invalid, so any attempt to compute a slice from it will fail.
+///
+/// If the size of the file is changed while this is running, an error will be
+/// returned.
+fn compute_outboard(path: PathBuf) -> anyhow::Result<(blake3::Hash, Vec<u8>)> {
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    // compute outboard size so we can pre-allocate the buffer.
+    //
+    // outboard is ~1/16 of data size, so this will fail for really large files
+    // on really small devices. E.g. you want to transfer a 1TB file from a pi4 with 1gb ram.
+    //
+    // The way to solve this would be to have larger blocks than the blake3 chunk size of 1024.
+    // I think we really want to keep the outboard in memory for simplicity.
+    let outboard_size = usize::try_from(bao::encode::outboard_size(len))
+        .context("outboard too large to fit in memory")?;
+    let mut outboard = Vec::with_capacity(outboard_size);
+
+    // copy the file into the encoder. Data will be skipped by the encoder in outboard mode.
+    let outboard_cursor = std::io::Cursor::new(&mut outboard);
+    let mut encoder = bao::encode::Encoder::new_outboard(outboard_cursor);
+
+    // the length we have actually written, should be the same as the length of the file.
+    let len2 = std::io::copy(&mut file, &mut encoder)?;
+    // this can fail if the file was appended to during encoding.
+    anyhow::ensure!(len == len2, "file changed during encoding");
+    // this flips the outboard encoding from post-order to pre-order
+    let hash = encoder.finalize()?;
+    anyhow::Ok((hash, outboard))
+}
+
 /// Creates a database of blobs (stored in outboard storage) and Collections, stored in memory.
 /// Returns a the hash of the collection created by the given list of DataSources
 pub async fn create_db(data_sources: Vec<DataSource>) -> Result<(Database, bao::Hash)> {
@@ -301,19 +337,24 @@ pub async fn create_db(data_sources: Vec<DataSource>) -> Result<(Database, bao::
                     "can only transfer blob data: {}",
                     path.display()
                 );
-                let data = tokio::fs::read(&path).await?;
-                let (outboard, hash) = bao::encode::outboard(&data);
+                // spawn a blocking task for computing the hash and outboard.
+                // pretty sure this is best to remain sync even once bao is async.
+                let path2 = path.clone();
+                let (hash, outboard) =
+                    tokio::task::spawn_blocking(move || compute_outboard(path2)).await??;
 
-                println!("- {}: {} bytes", hash.to_hex(), data.len());
+                anyhow::ensure!(outboard.len() >= 8);
+                let size = u64::from_le_bytes(outboard[..8].try_into().unwrap());
+                println!("- {}: {} bytes", hash.to_hex(), size);
                 db.insert(
                     hash,
                     BlobOrCollection::Blob(Data {
                         outboard: Bytes::from(outboard),
                         path: path.clone(),
-                        size: data.len() as u64,
+                        size,
                     }),
                 );
-                total_blobs_size += data.len() as u64;
+                total_blobs_size += size;
                 let name = path
                     .file_name()
                     .and_then(|s| s.to_str())

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -84,7 +84,7 @@ impl From<ed25519_dalek::Keypair> for Keypair {
 ///
 /// The [`PeerId`] implements both `Display` and `FromStr` which can be used to
 /// (de)serialise to human-readable and relatively safely transferrable strings.
-#[derive(Clone, PartialEq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy)]
 pub struct PeerId(PublicKey);
 
 impl From<PublicKey> for PeerId {

--- a/src/tls/verifier.rs
+++ b/src/tls/verifier.rs
@@ -210,7 +210,7 @@ impl From<certificate::ParseError> for rustls::Error {
         use webpki::Error::*;
         match e {
             BadDer => rustls::Error::InvalidCertificateEncoding,
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
         }
     }
 }
@@ -222,7 +222,7 @@ impl From<certificate::VerificationError> for rustls::Error {
             UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
                 rustls::Error::InvalidCertificateSignatureType
             }
-            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+            e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
         }
     }
 }


### PR DESCRIPTION
this also makes possible handling >4gb on 32 bit systems, and makes sendme usable on machines with little memory.

Since we can now handle >4GB on 32 bit systems, also upgrade size to u64.