### PR TITLE
feat: Provide a single ticket to fetch a hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
+ "serde",
  "signature",
 ]
 
@@ -514,6 +515,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
+ "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1724,6 +1726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1.3.0"
 clap = { version = "4", features = ["derive"] }
 console = "0.15.5"
 der = { version = "0.6.1", features = ["alloc", "derive"] }
-ed25519-dalek = "1.0.1"
+ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
 hex = "0.4.3"
 indicatif = { version = "0.17.2", features = ["tokio"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,15 +40,12 @@ enum Commands {
         key: Option<PathBuf>,
     },
     /// Fetch some data by hash.
-    ///
-    /// The hash must be provided by either the positional argument or can be provided by
-    /// the ticket.  When using a ticket the hash, peer ID, authentication token and provider address are all ignored and provided by the ticket.
     #[clap(about = "Fetch the data from the hash")]
     Get {
         /// The root hash to retrieve.
         hash: bao::Hash,
-        #[clap(long, short)]
         /// PeerId of the provider.
+        #[clap(long, short)]
         peer: PeerId,
         /// The authentication token to present to the server.
         #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,10 +290,10 @@ async fn get_interactive(
                 mut reader,
                 name,
             } => {
-                println!("  {}", style(format!("Receiving {hash}...")).bold().dim());
+                let name = name.map_or_else(|| hash.to_string(), |n| n);
+                pb.set_message(format!("Receiving {name}..."));
 
                 if let Some(ref outpath) = out {
-                    let name = name.map_or_else(|| hash.to_string(), |n| n);
                     tokio::fs::create_dir_all(outpath)
                         .await
                         .context("Unable to create directory {outpath}")?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -187,6 +187,48 @@ impl FromStr for AuthToken {
     }
 }
 
+/// Serde support for [`bao::Hash`].
+///
+/// Decorate the `bao::Hash` field with `#[serde(with = "crate::protocol::serde_hash")]` to
+/// use this.
+pub mod serde_hash {
+    use std::fmt;
+
+    use serde::{de, Deserializer, Serializer};
+
+    pub fn serialize<S>(hash: &bao::Hash, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        s.serialize_bytes(hash.as_bytes())
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<bao::Hash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        d.deserialize_bytes(HashVisitor)
+    }
+
+    struct HashVisitor;
+
+    impl<'de> de::Visitor<'de> for HashVisitor {
+        type Value = bao::Hash;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "an array of 32 bytes containing hash data")
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let bytes: [u8; 32] = v.try_into().map_err(E::custom)?;
+            Ok(bao::Hash::from(bytes))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -467,21 +467,18 @@ async fn write_response<W: AsyncWrite + Unpin>(
 
 /// A token containing everything to get a file from the provider.
 ///
-/// This token contains various things needed for getting a file from a provider:
-///
-/// - The *hash* to retrieve.
-/// - The *peer ID* identifying the provider.
-/// - The *socket address* the provider is listening on.
-/// - The *authentication token* with permission for the root hash.
-///
 /// It is a single item which can be easily serialised and deserialised.  The [`Display`]
 /// and [`FromStr`] implementations serialise to hex.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
+    /// The hash to retrieve.
     #[serde(with = "crate::protocol::serde_hash")]
     pub hash: bao::Hash,
+    /// The peer ID identifying the provider.
     pub peer: PeerId,
+    /// The socket address the provider is listening on.
     pub addr: SocketAddr,
+    /// The authentication token with permission to retrieve the hash.
     pub token: AuthToken,
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
+use serde::{Deserialize, Serialize};
 use ssh_key::LineEnding;
 
 // TODO: change?
@@ -84,7 +85,7 @@ impl From<ed25519_dalek::Keypair> for Keypair {
 ///
 /// The [`PeerId`] implements both `Display` and `FromStr` which can be used to
 /// (de)serialise to human-readable and relatively safely transferrable strings.
-#[derive(Clone, PartialEq, Copy)]
+#[derive(Clone, PartialEq, Eq, Copy, Serialize, Deserialize)]
 pub struct PeerId(PublicKey);
 
 impl From<PublicKey> for PeerId {


### PR DESCRIPTION
This adds a ticket format which enables fetching a hash using a single "ticket" which contains all the connection details.  With an IPv4 address this just over 200 bytes long.

# Reviewing

- Probably want to start with `Ticket` in `provider.rs`
- The `protocol::serde_hash` module will need merging with #48 (thanks for the code :wink:)
- The semantics of the `get` command are a bit messy now, everything is optional and the code errors out manually.  Maybe we should have a `get-ticket` sub-command instead which would make the semantics a lot more obvious.
- Note this doesn't target the main branch but rather #52.