### PR TITLE
feat: Looser dependencies as it is a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,36 +11,36 @@ repository = "https://github.com/n0-computer/sendme"
 rust-version = "1.63"
 
 [dependencies]
-anyhow = { version = "1.0.68", features = ["backtrace"] }
+anyhow = { version = "1", features = ["backtrace"] }
 bao = "0.12.1"
 blake3 = "1.3.3"
-bytes = "1.3.0"
+bytes = "1"
 clap = { version = "4", features = ["derive"] }
 console = "0.15.5"
-der = { version = "0.6.1", features = ["alloc", "derive"] }
+der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
-genawaiter = { version = "0.99.1", features = ["futures03"] }
+genawaiter = { version = "0.99", features = ["futures03"] }
 hex = "0.4.3"
-indicatif = { version = "0.17.2", features = ["tokio"] }
-is-terminal = "0.4.2"
-postcard = { version = "1.0.2", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
+indicatif = { version = "0.17", features = ["tokio"] }
+is-terminal = "0.4"
+postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"
-rcgen = "0.10.0"
+rcgen = "0.10"
 ring = "0.16.20"
 rustls = { version = "0.20.8", default-features = false, features = ["dangerous_configuration"] }
 s2n-quic = { version = "1.14.0", default-features = false, features = [ "provider-tls-rustls", "provider-address-token-default" ] }
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 ssh-key = { version = "0.5.1", features = ["ed25519", "std", "rand_core"] }
-tempfile = "3.3.0"
-thiserror = "1.0.38"
-tokio = { version = "1.24.1", features = ["full"] }
+tempfile = "3"
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io-util", "io"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-webpki = "0.22.0"
-x509-parser = "0.14.0"
-zeroize = "1.5.7"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+webpki = "0.22"
+x509-parser = "0.14"
+zeroize = "1.5"
 
 
 [dev-dependencies]


### PR DESCRIPTION
This loosens quite a few dependencies which makes it easier to use
sendme as a library.  Some of these are required to be compatbible to
deltachat's Cargo.lock file which is otherwise suitable.  Though some
of these are a bit more gratuitious loosening of deps.