### PR TITLE
refactor: switch to callbacks instead of events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -439,7 +439,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -672,37 +672,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "futures-core",
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error 0.4.12",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1281,40 +1250,14 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4",
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -1328,12 +1271,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1805,7 +1742,6 @@ dependencies = [
  "der",
  "ed25519-dalek",
  "futures",
- "genawaiter",
  "hex",
  "indicatif",
  "is-terminal",
@@ -2019,17 +1955,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ console = "0.15.5"
 der = { version = "0.6.1", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
-genawaiter = { version = "0.99.1", features = ["futures03"] }
 hex = "0.4.3"
 indicatif = { version = "0.17.2", features = ["tokio"] }
 is-terminal = "0.4.2"

--- a/src/get.rs
+++ b/src/get.rs
@@ -200,13 +200,9 @@ where
 
 /// Read next response, and if `Res::Found`, reads the next blob of data off the reader.
 ///
-/// Returns an `AsyncReader` and a `JoinHandle`.
-///
+/// Returns an `AsyncReader`
 /// The `AsyncReader` can be used to read the content.
-///
-/// The `JoinHandle` task must be `await`-ed to get back the reader to read the next message.
 async fn handle_blob_response<
-    'a,
     R: AsyncRead + futures::io::AsyncRead + Send + Sync + Unpin + 'static,
 >(
     hash: bao::Hash,
@@ -228,13 +224,6 @@ async fn handle_blob_response<
                     assert!(buffer.is_empty());
                     let decoder = AsyncSliceDecoder::new(reader, hash, 0, size);
                     Ok(decoder)
-                    // let (recv, mut send) = tokio::io::duplex(8192);
-                    // let task = tokio::task::spawn(async move {
-                    //     let mut decoder = AsyncSliceDecoder::new(reader, hash, 0, size);
-                    //     tokio::io::copy(&mut decoder, &mut send).await?;
-                    //     anyhow::Ok(decoder.into_inner())
-                    // });
-                    // Ok((Box::new(recv), task))
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
-use std::{io::Write, net::SocketAddr, path::PathBuf, str::FromStr};
+use std::{net::SocketAddr, path::PathBuf, str::FromStr};
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use console::style;
-use futures::StreamExt;
 use indicatif::{HumanDuration, ProgressBar, ProgressDrawTarget, ProgressState, ProgressStyle};
 use is_terminal::IsTerminal;
 use sendme::protocol::AuthToken;
 use sendme::provider::{BlobOrCollection, Ticket};
-use tracing::trace;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use sendme::{get, provider, Keypair, PeerId};
@@ -81,22 +81,27 @@ enum Commands {
 
 struct OutWriter {
     is_atty: bool,
-    stderr: std::io::Stderr,
+    stderr: Mutex<tokio::io::Stderr>,
 }
 
 impl OutWriter {
     pub fn new() -> Self {
         let stderr = std::io::stderr();
         let is_atty = stderr.is_terminal();
-        Self { is_atty, stderr }
+        let stderr = tokio::io::stderr();
+        Self {
+            is_atty,
+            stderr: Mutex::new(stderr),
+        }
     }
 }
 
 impl OutWriter {
-    pub fn println(&mut self, content: impl AsRef<[u8]>) {
+    pub async fn println(&self, content: impl AsRef<[u8]>) {
         if self.is_atty {
-            self.stderr.write_all(content.as_ref()).unwrap();
-            self.stderr.write_all(b"\n").unwrap();
+            let stderr = &mut *self.stderr.lock().await;
+            stderr.write_all(content.as_ref()).await.unwrap();
+            stderr.write_all(b"\n").await.unwrap();
         }
     }
 }
@@ -151,13 +156,15 @@ async fn main() -> Result<()> {
             auth_token,
             key,
         } => {
-            let mut out_writer = OutWriter::new();
+            let out_writer = OutWriter::new();
             let keypair = get_keypair(key).await?;
 
             let mut tmp_path = None;
 
             let sources = if let Some(path) = path {
-                out_writer.println(format!("Reading {}", path.display()));
+                out_writer
+                    .println(format!("Reading {}", path.display()))
+                    .await;
                 if path.is_dir() {
                     let mut paths = Vec::new();
                     let mut iter = tokio::fs::read_dir(&path).await?;
@@ -201,10 +208,16 @@ async fn main() -> Result<()> {
             }
             let provider = builder.spawn()?;
 
-            out_writer.println(format!("PeerID: {}", provider.peer_id()));
-            out_writer.println(format!("Auth token: {}", provider.auth_token()));
+            out_writer
+                .println(format!("PeerID: {}", provider.peer_id()))
+                .await;
+            out_writer
+                .println(format!("Auth token: {}", provider.auth_token()))
+                .await;
             if let Some(hash) = hash {
-                out_writer.println(format!("All-in-one ticket: {}", provider.ticket(hash)));
+                out_writer
+                    .println(format!("All-in-one ticket: {}", provider.ticket(hash)))
+                    .await;
             }
             provider.join().await?;
 
@@ -243,31 +256,47 @@ async fn get_interactive(
     token: AuthToken,
     out: Option<PathBuf>,
 ) -> Result<()> {
-    let mut out_writer = OutWriter::new();
-    out_writer.println(format!("Fetching: {}", hash.to_hex()));
+    let out_writer = OutWriter::new();
+    out_writer
+        .println(format!("Fetching: {}", hash.to_hex()))
+        .await;
 
-    out_writer.println(format!("{} Connecting ...", style("[1/3]").bold().dim()));
+    out_writer
+        .println(format!("{} Connecting ...", style("[1/3]").bold().dim()))
+        .await;
 
     let pb = ProgressBar::hidden();
-    let stream = get::run(hash, token, opts);
-    tokio::pin!(stream);
-    while let Some(event) = stream.next().await {
-        trace!("client event: {:?}", event);
-        match event? {
-            get::Event::Connected => {
-                out_writer.println(format!("{} Requesting ...", style("[2/3]").bold().dim()));
+    let stats = get::run(
+        hash,
+        token,
+        opts,
+        || {
+            let out_writer = &out_writer;
+            async move {
+                out_writer
+                    .println(format!("{} Requesting ...", style("[2/3]").bold().dim()))
+                    .await;
+                Ok(())
             }
-            get::Event::ReceivedCollection(collection) => {
+        },
+        |collection| {
+            let pb = &pb;
+            let out_writer = &out_writer;
+            async move {
                 let name = collection.name();
                 let total_entries = collection.total_entries();
                 let size = collection.total_blobs_size();
-                out_writer.println(format!(
-                    "{} Downloading {name}...",
-                    style("[3/3]").bold().dim()
-                ));
-                out_writer.println(format!(
-                    "  {total_entries} file(s) with total transfer size {size}"
-                ));
+                out_writer
+                    .println(format!(
+                        "{} Downloading {name}...",
+                        style("[3/3]").bold().dim()
+                    ))
+                    .await;
+                out_writer
+                    .println(format!(
+                        "  {total_entries} file(s) with total transfer size {size}"
+                    ))
+                    .await;
                 pb.set_style(
                     ProgressStyle::with_template(PROGRESS_STYLE)
                         .unwrap()
@@ -281,12 +310,14 @@ async fn get_interactive(
                 );
                 pb.set_length(size);
                 pb.set_draw_target(ProgressDrawTarget::stderr());
+
+                Ok(())
             }
-            get::Event::Receiving {
-                hash,
-                mut reader,
-                name,
-            } => {
+        },
+        |hash, mut reader, name| {
+            let out = &out;
+            let pb = &pb;
+            async move {
                 let name = name.map_or_else(|| hash.to_string(), |n| n);
                 pb.set_message(format!("Receiving {name}..."));
 
@@ -319,12 +350,17 @@ async fn get_interactive(
                     let mut stdout = tokio::io::stdout();
                     tokio::io::copy(&mut reader, &mut stdout).await?;
                 }
+
+                Ok(reader)
             }
-            get::Event::Done(stats) => {
-                pb.finish_and_clear();
-                out_writer.println(format!("Done in {}", HumanDuration(stats.elapsed)));
-            }
-        }
-    }
+        },
+    )
+    .await?;
+
+    pb.finish_and_clear();
+    out_writer
+        .println(format!("Done in {}", HumanDuration(stats.elapsed)))
+        .await;
+
     Ok(())
 }


### PR DESCRIPTION
This allows avoiding the double copy when receiving data.