### PR TITLE
Remove double sizes - second attempt

### DIFF
--- a/src/bao_slice_decoder.rs
+++ b/src/bao_slice_decoder.rs
@@ -499,6 +499,12 @@ pub struct AsyncSliceDecoder<R: tokio::io::AsyncRead + Unpin> {
 }
 
 impl<R: tokio::io::AsyncRead + Unpin> AsyncSliceDecoder<R> {
+    /// Create a new slice decoder for the given hash and range
+    ///
+    /// The hash is the hash of the entire stream, and the range is the range being sent.
+    /// If you want to decode an entire file and do not know the length, it is OK to pass
+    /// 0 as the start and u64::MAX as the length. The length will then be truncated to
+    /// the actual length of the stream, which is the first 8 bytes of the stream.
     pub fn new(inner: R, hash: blake3::Hash, start: u64, len: u64) -> Self {
         Self {
             inner: SliceValidator::new(inner, hash, start, len),

--- a/src/bao_slice_decoder.rs
+++ b/src/bao_slice_decoder.rs
@@ -579,52 +579,82 @@ mod tests {
     fn test_decode_all_sync_impl(len: u64) {
         // create a slice encoding the entire data - equivalent to the bao inline encoding
         let test_data = create_test_data(len as usize);
-        let (hash, slice) = encode_slice(&test_data, 0, len);
+        let (hash, encoded) = encode_slice(&test_data, 0, len);
 
         // test just validation without reading
-        let mut cursor = Cursor::new(&slice);
+        let mut cursor = Cursor::new(&encoded);
         let validator = SliceValidator::new(&mut cursor, hash, 0, len);
         for item in validator {
             assert!(item.is_ok());
         }
         // check that we have read the entire slice
-        assert_eq!(cursor.position(), slice.len() as u64);
+        assert_eq!(cursor.position(), encoded.len() as u64);
 
         // test validation and reading
-        let mut cursor = std::io::Cursor::new(&slice);
+        let mut cursor = std::io::Cursor::new(&encoded);
         let mut reader = SliceDecoder::new(&mut cursor, &hash, 0, len);
         let mut data = vec![];
         reader.read_to_end(&mut data).unwrap();
         assert_eq!(data, test_data);
 
         // check that we have read the entire slice
-        assert_eq!(cursor.position(), slice.len() as u64);
+        assert_eq!(cursor.position(), encoded.len() as u64);
+
+        // add some garbage
+        let mut encoded_with_garbage = encoded.clone();
+        encoded_with_garbage.extend_from_slice(vec![0u8; 1234].as_slice());
+        let mut cursor = std::io::Cursor::new(&encoded_with_garbage);
+
+        // check that reading with a size > end works
+        let mut reader = SliceDecoder::new(&mut cursor, &hash, 0, u64::MAX);
+        let mut data = vec![];
+        reader.read_to_end(&mut data).unwrap();
+        assert_eq!(data, test_data);
+
+        // check that we have read just the encoded data, and not some extra bytes
+        let inner = reader.into_inner();
+        assert_eq!(inner.position(), encoded.len() as u64);
     }
 
     /// Test implementation for the test_decode_all test, to be called by both proptest and hardcoded tests
     async fn test_decode_all_async_impl(len: u64) {
         // create a slice encoding the entire data - equivalent to the bao inline encoding
         let test_data = create_test_data(len as usize);
-        let (hash, slice) = encode_slice(&test_data, 0, len);
+        let (hash, encoded) = encode_slice(&test_data, 0, len);
 
         // test just validation without reading
-        let mut cursor = std::io::Cursor::new(&slice);
+        let mut cursor = std::io::Cursor::new(&encoded);
         let mut validator = AsyncSliceValidator::new(&mut cursor, hash, 0, len);
         while let Some(item) = validator.next().await {
             assert!(item.is_ok());
         }
         // check that we have read the entire slice
-        assert_eq!(cursor.position(), slice.len() as u64);
+        assert_eq!(cursor.position(), encoded.len() as u64);
 
         // test validation and reading
-        let mut cursor = std::io::Cursor::new(&slice);
+        let mut cursor = std::io::Cursor::new(&encoded);
         let mut reader = AsyncSliceDecoder::new(&mut cursor, hash, 0, len);
         let mut data = vec![];
         reader.read_to_end(&mut data).await.unwrap();
         assert_eq!(data, test_data);
 
         // check that we have read the entire slice
-        assert_eq!(cursor.position(), slice.len() as u64);
+        assert_eq!(cursor.position(), encoded.len() as u64);
+
+        // add some garbage
+        let mut encoded_with_garbage = encoded.clone();
+        encoded_with_garbage.extend_from_slice(vec![0u8; 1234].as_slice());
+        let mut cursor = std::io::Cursor::new(&encoded_with_garbage);
+
+        // check that reading with a size > end works
+        let mut reader = AsyncSliceDecoder::new(&mut cursor, hash, 0, u64::MAX);
+        let mut data = vec![];
+        reader.read_to_end(&mut data).await.unwrap();
+        assert_eq!(data, test_data);
+
+        // check that we have read just the encoded data, and not some extra bytes
+        let inner = reader.into_inner();
+        assert_eq!(inner.position(), encoded.len() as u64);
     }
 
     /// Test implementation for the test_decode_part test, to be called by both proptest and hardcoded tests

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -1,7 +1,4 @@
-use std::io::Read;
-
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -16,16 +13,9 @@ pub struct Collection {
 }
 
 impl Collection {
-    pub fn decode_from(encoded: Bytes, hash: bao::Hash) -> Result<Self> {
-        // verify that the content of data matches the expected hash
-        let mut decoder = bao::decode::Decoder::new(std::io::Cursor::new(&encoded[..]), &hash);
-        // decoded size can be at most encoded size
-        let mut data = Vec::with_capacity(encoded.len());
-        decoder
-            .read_to_end(&mut data)
-            .context("hash of Collection data does not match")?;
+    pub fn deserialize_from(data: &[u8]) -> Result<Self> {
         let c: Collection =
-            postcard::from_bytes(&data).context("failed to serialize Collection data")?;
+            postcard::from_bytes(data).context("failed to serialize Collection data")?;
         Ok(c)
     }
 

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -13,7 +13,7 @@ pub struct Collection {
 }
 
 impl Collection {
-    pub fn deserialize_from(data: &[u8]) -> Result<Self> {
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
         let c: Collection =
             postcard::from_bytes(data).context("failed to serialize Collection data")?;
         Ok(c)

--- a/src/get.rs
+++ b/src/get.rs
@@ -218,9 +218,9 @@ async fn handle_blob_response<
                 // blob data not found
                 Res::NotFound => Err(anyhow!("data for {} not found", hash.to_hex()))?,
                 // next blob in collection will be sent over
-                Res::Found { size } => {
+                Res::Found => {
                     assert!(buffer.is_empty());
-                    let decoder = AsyncSliceDecoder::new(reader, hash, 0, size);
+                    let decoder = AsyncSliceDecoder::new(reader, hash, 0, u64::MAX);
                     Ok(decoder)
                 }
             }

--- a/src/get.rs
+++ b/src/get.rs
@@ -141,7 +141,7 @@ where
                         let data = read_bao_encoded(&mut reader, hash).await?;
 
                         // decode the collection
-                        let collection = Collection::deserialize_from(&data)?;
+                        let collection = Collection::from_bytes(&data)?;
                         on_collection(collection.clone()).await?;
 
                         // expect to get blob data in the order they appear in the collection

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::debug;
 
+use crate::bao_slice_decoder::AsyncSliceDecoder;
+
 /// Maximum message size is limited to 100MiB for now.
 const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 100;
 
@@ -50,8 +52,6 @@ pub enum Res {
     /// A stream of boa data that decodes to a `Collection` is sent as the next message,
     /// followed by `Res::Found` responses, send in the order indicated in the `Collection`.
     FoundCollection {
-        /// The size of the coming data in bytes, raw content size.
-        size: u64,
         /// The size of the raw data we are planning to transfer
         total_blobs_size: u64,
     },
@@ -117,6 +117,18 @@ pub async fn read_size_data<R: AsyncRead + Unpin>(
     }
     debug!("finished reading");
     Ok(buffer.split_to(size).freeze())
+}
+
+/// Read and decode the given bao encoded data from the provided source.
+///
+/// After the data is read successfully, the reader will be at the end of the data.
+/// If there is an error, the reader can be anywhere, so it is recommended to discard it.
+pub async fn read_bao_encoded<R: AsyncRead + Unpin>(reader: R, hash: bao::Hash) -> Result<Vec<u8>> {
+    let mut decoder = AsyncSliceDecoder::new(reader, hash, 0, u64::MAX);
+    // we don't know the size yet, so we just allocate a reasonable amount
+    let mut decoded = Vec::with_capacity(4096);
+    decoder.read_to_end(&mut decoded).await?;
+    Ok(decoded)
 }
 
 /// Return a buffer of the data, based on the length prefix, from the given source.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -45,10 +45,7 @@ pub struct Response {
 pub enum Res {
     NotFound,
     // If found, a stream of bao data is sent as next message.
-    Found {
-        /// The size of the coming data in bytes, raw content size.
-        size: u64,
-    },
+    Found,
     /// Indicates that the given hash referred to a collection of multiple blobs
     /// A stream of boa data that decodes to a `Collection` is sent as the next message,
     /// followed by `Res::Found` responses, send in the order indicated in the `Collection`.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -250,7 +250,6 @@ async fn handle_stream(db: Database, token: AuthToken, stream: BidirectionalStre
                             &mut out_buffer,
                             request.id,
                             Res::FoundCollection {
-                                size: data.len() as u64,
                                 total_blobs_size: c.total_blobs_size,
                             },
                         )

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -312,7 +312,7 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
             size,
         })) => {
             debug!("found {}", name.to_hex());
-            write_response(&mut writer, buffer, id, Res::Found { size: *size }).await?;
+            write_response(&mut writer, buffer, id, Res::Found).await?;
 
             debug!("writing data");
             let path = path.clone();


### PR DESCRIPTION
I was overcomplicating this. I thought you need the size for the slice decoder, but you don't. If you set max to u64::MAX, it will just read to the end and not more.

The way it works is that it reads the 8 byte header first, and then truncates the range to the valid range.

So all that is needed to remove the sizes is to... just remove the sizes.