### PR TITLE
perf: wrap the SliceExtractor in a BufReader when encoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn perf_big_file() -> Result<()> {
+        let port: u16 = 4445;
+
+        let size = 1024 * 1024 * 1024;
+        transfer_random_data(vec![("hello_world", size)], port).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn perf_many_files() -> Result<()> {
+        let port: u16 = 4445;
+
+        let sizes = (0..128)
+            .map(|i| (format!("hello world {i}"), 1024 * 1024 * 8))
+            .collect();
+        transfer_random_data(sizes, port).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn empty_files() -> Result<()> {
         // try to transfer as many files as possible without hitting a limit
         // booo 400 is too small :(

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -325,13 +325,14 @@ async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
                 let file_reader = std::fs::File::open(&path)?;
                 let outboard_reader = std::io::Cursor::new(outboard);
                 let mut wrapper = SyncIoBridge::new(&mut writer);
-                let mut slice_extractor = bao::encode::SliceExtractor::new_outboard(
+                let slice_extractor = bao::encode::SliceExtractor::new_outboard(
                     file_reader,
                     outboard_reader,
                     0,
                     size,
                 );
-                let _copied = std::io::copy(&mut slice_extractor, &mut wrapper)?;
+                let mut reader = std::io::BufReader::with_capacity(1 << 16, slice_extractor);
+                let _copied = std::io::copy(&mut reader, &mut wrapper)?;
                 std::io::Result::Ok(writer)
             })
             .await??;


### PR DESCRIPTION
Buffer size is chosen to be 2^16, so about what I think an ideal bao block size would be. Might be better to make this even bigger, but the default size of BufReader is definitely too small.

This is WIP since it still needs an easy way to see if it makes a difference. Thinking about having a large test that is disabled by default and that you can run manually, or even flamegraph it.