### PR TITLE
ref: Take the collection hash from the db creation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,8 @@ mod tests {
         let (_, expect_hash) = bao::encode::outboard(&data);
         let expect_name = Some(filename.to_string());
 
-        let (db, hash) = provider::create_db(vec![provider::DataSource::File(path)]).await?;
+        let (db, hash) =
+            provider::create_collection(vec![provider::DataSource::File(path)]).await?;
         let provider = provider::Provider::builder(db).bind_addr(addr).spawn()?;
 
         async fn run_client(
@@ -197,7 +198,7 @@ mod tests {
             expects.push((Some(name), path, hash));
         }
 
-        let (db, collection_hash) = provider::create_db(files).await?;
+        let (db, collection_hash) = provider::create_collection(files).await?;
 
         let addr = format!("127.0.0.1:{port}").parse().unwrap();
         let provider = provider::Provider::builder(db).bind_addr(addr).spawn()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use indicatif::{
 };
 use is_terminal::IsTerminal;
 use sendme::protocol::AuthToken;
-use sendme::provider::{BlobOrCollection, Ticket};
+use sendme::provider::Ticket;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -191,15 +191,7 @@ async fn main() -> Result<()> {
                 vec![provider::DataSource::File(path_buf)]
             };
 
-            let (db, _) = provider::create_db(sources).await?;
-            let hash = db
-                .iter()
-                .filter_map(|(hash, item)| match item {
-                    BlobOrCollection::Collection(_) => Some(hash),
-                    _ => None,
-                })
-                .next()
-                .copied();
+            let (db, hash) = provider::create_db(sources).await?;
             let mut builder = provider::Provider::builder(db).keypair(keypair);
             if let Some(addr) = addr {
                 builder = builder.bind_addr(addr);
@@ -216,11 +208,9 @@ async fn main() -> Result<()> {
             out_writer
                 .println(format!("Auth token: {}", provider.auth_token()))
                 .await;
-            if let Some(hash) = hash {
-                out_writer
-                    .println(format!("All-in-one ticket: {}", provider.ticket(hash)))
-                    .await;
-            }
+            out_writer
+                .println(format!("All-in-one ticket: {}", provider.ticket(hash)))
+                .await;
             provider.join().await?;
 
             // Drop tempath to signal it can be destroyed

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ async fn main() -> Result<()> {
                 vec![provider::DataSource::File(path_buf)]
             };
 
-            let (db, hash) = provider::create_db(sources).await?;
+            let (db, hash) = provider::create_collection(sources).await?;
             let mut builder = provider::Provider::builder(db).keypair(keypair);
             if let Some(addr) = addr {
                 builder = builder.bind_addr(addr);

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -399,7 +399,7 @@ fn compute_outboard(path: PathBuf) -> anyhow::Result<(blake3::Hash, Vec<u8>)> {
 
 /// Creates a database of blobs (stored in outboard storage) and Collections, stored in memory.
 /// Returns a the hash of the collection created by the given list of DataSources
-pub async fn create_db(data_sources: Vec<DataSource>) -> Result<(Database, bao::Hash)> {
+pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Database, bao::Hash)> {
     // +1 is for the collection itself
     let mut db = HashMap::with_capacity(data_sources.len() + 1);
     let mut blobs = Vec::with_capacity(data_sources.len());


### PR DESCRIPTION
The database now returns the hash of the collection created.  There's
no need to go manually looking for this anymore, just use it.