### PR TITLE
Enforce debug instances

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Wmissing_debug_implementations"]

--- a/src/bao_slice_decoder.rs
+++ b/src/bao_slice_decoder.rs
@@ -77,6 +77,7 @@ fn right_descendant(offset: NodeNum, len: NodeNum) -> Option<NodeNum> {
     Some(offset)
 }
 
+#[derive(Debug)]
 pub struct SliceIter {
     len: u64,
     range: Range<u64>,
@@ -229,6 +230,7 @@ impl StreamItem {
     }
 }
 
+#[derive(Debug)]
 pub struct SliceValidator<R> {
     /// the inner reader
     inner: R,
@@ -493,6 +495,7 @@ impl<R: Read> Read for SliceDecoder<R> {
     }
 }
 
+#[derive(Debug)]
 pub struct AsyncSliceDecoder<R: tokio::io::AsyncRead + Unpin> {
     inner: SliceValidator<R>,
     current_item: Option<StreamItem>,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -155,6 +155,7 @@ impl Builder {
 /// is a shorthand to create a suitable [`Builder`].
 ///
 /// This runs a tokio task which can be aborted and joined if desired.
+#[derive(Debug)]
 pub struct Provider {
     listen_addr: SocketAddr,
     keypair: Keypair,


### PR DESCRIPTION
Implements https://github.com/n0-computer/iroh/issues/726

Note that I would prefer it if AsyncSliceDecoder would not have to be public in the first place, but I guess that is best left for another PR.