### PR TITLE
feat: switch printing from hex to base64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
-  MSRV: "1.63"
+  MSRV: "1.64"
 
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -445,7 +445,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
- "proc-macro-error 1.0.4",
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
@@ -678,37 +678,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "futures-core",
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error 0.4.12",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1287,40 +1256,14 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr 1.0.4",
+ "proc-macro-error-attr",
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "syn-mid",
  "version_check",
 ]
 
@@ -1334,12 +1277,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1812,7 +1749,6 @@ dependencies = [
  "der",
  "ed25519-dalek",
  "futures",
- "genawaiter",
  "hex",
  "indicatif",
  "postcard",
@@ -2025,17 +1961,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa8e7560a164edb1621a55d18a0c59abf49d360f47aa7b821061dd7eea7fac9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error 1.0.4",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1804,6 +1804,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bao",
+ "base64 0.21.0",
  "blake3",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.63"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 bao = "0.12.1"
+base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
@@ -21,7 +22,6 @@ der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
 genawaiter = { version = "0.99", features = ["futures03"] }
-hex = "0.4.3"
 indicatif = { version = "0.17", features = ["tokio"] }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"
@@ -43,6 +43,7 @@ zeroize = "1.5"
 
 
 [dev-dependencies]
+hex = "0.4.3"
 proptest = "1.0.0"
 rand = "0.7"
 testdir = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ console = "0.15.5"
 der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
-genawaiter = { version = "0.99", features = ["futures03"] }
 indicatif = { version = "0.17", features = ["tokio"] }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["dignifiedquire <me@dignifiedquire.com>"]
 repository = "https://github.com/n0-computer/sendme"
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml
-rust-version = "1.63"
+rust-version = "1.64"
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/src/get.rs
+++ b/src/get.rs
@@ -18,6 +18,7 @@ use crate::protocol::{
     read_bao_encoded, read_lp_data, write_lp, AuthToken, Handshake, Request, Res, Response,
 };
 use crate::tls::{self, Keypair, PeerId};
+use crate::util;
 
 const MAX_DATA_SIZE: u64 = 1024 * 1024 * 1024;
 
@@ -223,7 +224,10 @@ async fn handle_blob_response<
                     "Unexpected message from provider. Ending transfer early."
                 ))?,
                 // blob data not found
-                Res::NotFound => Err(anyhow!("data for {} not found", hash.to_hex()))?,
+                Res::NotFound => Err(anyhow!(
+                    "data for {} not found",
+                    util::encode(hash.as_bytes())
+                ))?,
                 // next blob in collection will be sent over
                 Res::Found => {
                     assert!(buffer.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod blobs;
 pub mod get;
 pub mod protocol;
 pub mod provider;
+pub mod util;
 
 mod bao_slice_decoder;
 mod tls;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use sendme::{get, provider, Keypair, PeerId};
+use sendme::{get, provider, util, Keypair, PeerId};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(version, about, long_about = None)]
@@ -189,8 +189,8 @@ async fn main() -> Result<()> {
             if let Some(addr) = addr {
                 builder = builder.bind_addr(addr);
             }
-            if let Some(ref hex) = auth_token {
-                let auth_token = AuthToken::from_str(hex)?;
+            if let Some(ref encoded) = auth_token {
+                let auth_token = AuthToken::from_str(encoded)?;
                 builder = builder.auth_token(auth_token);
             }
             let provider = builder.spawn()?;
@@ -243,7 +243,7 @@ async fn get_interactive(
 ) -> Result<()> {
     let out_writer = OutWriter::new();
     out_writer
-        .println(format!("Fetching: {}", hash.to_hex()))
+        .println(format!("Fetching: {}", util::encode(hash.as_bytes())))
         .await;
 
     out_writer

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -17,6 +17,8 @@ pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
 use serde::{Deserialize, Serialize};
 use ssh_key::LineEnding;
 
+use crate::util;
+
 // TODO: change?
 const P2P_ALPN: [u8; 6] = *b"libp2p";
 
@@ -96,35 +98,35 @@ impl From<PublicKey> for PeerId {
 
 impl Debug for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PeerId({})", hex::encode(self.0.as_bytes()))
+        write!(f, "PeerId({})", util::encode(self.0.as_bytes()))
     }
 }
 
-/// Serialises the [`PeerId`] to hex.
+/// Serialises the [`PeerId`] to base64.
 ///
 /// [`FromStr`] is capable of deserialising this format.
 impl Display for PeerId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(self.0.as_bytes()))
+        write!(f, "{}", util::encode(self.0.as_bytes()))
     }
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum PeerIdError {
     #[error("encoding: {0}")]
-    Hex(#[from] hex::FromHexError),
+    Base64(#[from] base64::DecodeError),
     #[error("key: {0}")]
     Key(#[from] ed25519_dalek::SignatureError),
 }
 
-/// Deserialises the [`PeerId`] from it's hex encoding.
+/// Deserialises the [`PeerId`] from it's base64 encoding.
 ///
 /// [`Display`] is capable of serialising this format.
 impl FromStr for PeerId {
     type Err = PeerIdError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = hex::decode(s)?;
+        let bytes = util::decode(s)?;
         let key = PublicKey::from_bytes(&bytes)?;
         Ok(PeerId(key))
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,11 @@
+use base64::{engine::general_purpose, Engine as _};
+
+/// Encode the given buffer into Base64 URL SAFE without padding.
+pub fn encode(buf: impl AsRef<[u8]>) -> String {
+    general_purpose::URL_SAFE_NO_PAD.encode(buf.as_ref())
+}
+
+/// Decode the given buffer from Base64 URL SAFE without padding.
+pub fn decode(buf: impl AsRef<str>) -> Result<Vec<u8>, base64::DecodeError> {
+    general_purpose::URL_SAFE_NO_PAD.decode(buf.as_ref())
+}


### PR DESCRIPTION
Why base64? 
Because most of the world uses it already, and the url safe version can be at least easily used in URLs. Also it is very fast :) 



<img width="661" alt="Screenshot 2023-02-02 at 18 27 41" src="https://user-images.githubusercontent.com/790842/216398079-fbf48601-06b1-4f41-a8f0-b3d2feaa5d88.png">


Closes n0-computer/iroh#728