### PR TITLE
isolate binary only dependencies behind a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
+ "is-terminal",
  "postcard",
  "proptest",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ bao = "0.12.1"
 base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = "1"
+clap = { version = "4", features = ["derive"], optional = true }
+console = { version = "0.15.5", optional = true }
 der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
+indicatif = { version = "0.17", features = ["tokio"], optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"
 rcgen = "0.10"
@@ -37,10 +40,6 @@ webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
 
-clap = { version = "4", features = ["derive"], optional = true }
-console = { version = "0.15.5", optional = true }
-indicatif = { version = "0.17", features = ["tokio"], optional = true }
-
 [dev-dependencies]
 hex = "0.4.3"
 proptest = "1.0.0"
@@ -48,6 +47,7 @@ rand = "0.7"
 testdir = "0.7.1"
 
 [features]
+default = ["cli"]
 cli = ["clap", "console", "indicatif"]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,9 @@ bao = "0.12.1"
 base64 = "0.21.0"
 blake3 = "1.3.3"
 bytes = "1"
-clap = { version = "4", features = ["derive"] }
-console = "0.15.5"
 der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
-indicatif = { version = "0.17", features = ["tokio"] }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 rand = "0.7"
 rcgen = "0.10"
@@ -40,9 +37,19 @@ webpki = "0.22"
 x509-parser = "0.14"
 zeroize = "1.5"
 
+clap = { version = "4", features = ["derive"], optional = true }
+console = { version = "0.15.5", optional = true }
+indicatif = { version = "0.17", features = ["tokio"], optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"
 proptest = "1.0.0"
 rand = "0.7"
 testdir = "0.7.1"
+
+[features]
+cli = ["clap", "console", "indicatif"]
+
+[[bin]]
+name = "sendme"
+required-features = ["cli"]

--- a/README.md
+++ b/README.md
@@ -40,15 +40,23 @@
 
 ## Usage
 
+### Cli
 Sending data
 ```sh
-$ ./senmde provide <file>
+$ ./sendme provide <file>
 ```
 
 Receiving data
 ```sh
 $ ./sendme get <hash>
 ```
+
+### As a library
+Disable default features when using `sendme` as a library:
+`sendme = { version: "...", default-features = false }`
+
+This removes dependencies that are only relevant when using `sendme` as
+a library.
 
 # License
 


### PR DESCRIPTION
closes n0-computer/iroh#738 

@flub thoughts? Is there a better way to structure this?
My only hesitation is that this makes using the cli via `cargo run` more cumbersome since we now always have to add the `--features="cli"` flag:
`cargo run --features="cli" -- provide FILE`
`cargo run --features="cli" -- get-ticket TICKET -o new_dir`