### PR TITLE
feat: introduce custom Hash type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,6 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
- "is-terminal",
  "postcard",
  "proptest",
  "rand 0.7.3",

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::util::Hash;
+
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Collection {
     ///
@@ -37,8 +39,7 @@ pub(crate) struct Blob {
     /// The name of this blob of data
     pub(crate) name: String,
     /// The hash of the blob of data
-    #[serde(with = "crate::protocol::serde_hash")]
-    pub(crate) hash: bao::Hash,
+    pub(crate) hash: Hash,
 }
 
 #[cfg(test)]
@@ -52,7 +53,8 @@ mod tests {
             hash: bao::Hash::from_hex(
                 "3aa61c409fd7717c9d9c639202af2fae470c0ef669be7ba2caea5779cb534e9d",
             )
-            .unwrap(),
+            .unwrap()
+            .into(),
         };
 
         let mut buf = bytes::BytesMut::zeroed(1024);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use sendme::{get, provider, util, Keypair, PeerId};
+use sendme::{get, provider, Hash, Keypair, PeerId};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(version, about, long_about = None)]
@@ -44,7 +44,7 @@ enum Commands {
     #[clap(about = "Fetch the data from the hash")]
     Get {
         /// The root hash to retrieve.
-        hash: bao::Hash,
+        hash: Hash,
         /// PeerId of the provider.
         #[clap(long, short)]
         peer: PeerId,
@@ -236,15 +236,13 @@ async fn get_keypair(key: Option<PathBuf>) -> Result<Keypair> {
 }
 
 async fn get_interactive(
-    hash: bao::Hash,
+    hash: Hash,
     opts: get::Options,
     token: AuthToken,
     out: Option<PathBuf>,
 ) -> Result<()> {
     let out_writer = OutWriter::new();
-    out_writer
-        .println(format!("Fetching: {}", util::encode(hash.as_bytes())))
-        .await;
+    out_writer.println(format!("Fetching: {}", hash)).await;
 
     out_writer
         .println(format!("{} Connecting ...", style("[1/3]").bold().dim()))
@@ -299,7 +297,7 @@ async fn get_interactive(
             Ok(())
         }
     };
-    let on_blob = |hash: blake3::Hash, mut reader, name: Option<String>| {
+    let on_blob = |hash: Hash, mut reader, name: Option<String>| {
         let out = &out;
         let pb = &pb;
         async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,7 @@ async fn get_interactive(
     out: Option<PathBuf>,
 ) -> Result<()> {
     let out_writer = OutWriter::new();
-    out_writer.println(format!("Fetching: {}", hash)).await;
+    out_writer.println(format!("Fetching: {hash}")).await;
 
     out_writer
         .println(format!("{} Connecting ...", style("[1/3]").bold().dim()))

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -20,12 +20,12 @@ use tracing::{debug, warn};
 use crate::blobs::{Blob, Collection};
 use crate::protocol::{read_lp, write_lp, AuthToken, Handshake, Request, Res, Response, VERSION};
 use crate::tls::{self, Keypair, PeerId};
-use crate::util;
+use crate::util::{self, Hash};
 
 const MAX_CONNECTIONS: u64 = 1024;
 const MAX_STREAMS: u64 = 10;
 
-pub type Database = Arc<HashMap<bao::Hash, BlobOrCollection>>;
+pub type Database = Arc<HashMap<Hash, BlobOrCollection>>;
 
 /// Builder for the [`Provider`].
 ///
@@ -174,7 +174,7 @@ pub enum Event {
     RequestReceived {
         connection_id: u64,
         request_id: u64,
-        hash: bao::Hash,
+        hash: Hash,
     },
     TransferCompleted {
         connection_id: u64,
@@ -218,7 +218,7 @@ impl Provider {
     /// Return a single token containing everything needed to get a hash.
     ///
     /// See [`Ticket`] for more details of how it can be used.
-    pub fn ticket(&self, hash: bao::Hash) -> Ticket {
+    pub fn ticket(&self, hash: Hash) -> Ticket {
         // TODO: Verify that the hash exists in the db?
         Ticket {
             hash,
@@ -274,7 +274,7 @@ async fn handle_stream(
         debug!("reading request");
         match read_lp::<_, Request>(&mut reader, &mut in_buffer).await? {
             Some((request, _size)) => {
-                let hash = bao::Hash::from(request.name);
+                let hash = request.name;
                 debug!("got request({})", request.id);
                 let _ = events.send(Event::RequestReceived {
                     connection_id,
@@ -285,7 +285,7 @@ async fn handle_stream(
                 match db.get(&hash) {
                     // We only respond to requests for collections, not individual blobs
                     Some(BlobOrCollection::Collection((outboard, data))) => {
-                        debug!("found collection {}", util::encode(hash.as_bytes()));
+                        debug!("found collection {}", hash);
 
                         let mut extractor = SliceExtractor::new_outboard(
                             std::io::Cursor::new(&data[..]),
@@ -335,7 +335,7 @@ async fn handle_stream(
                         });
                     }
                     _ => {
-                        debug!("not found {}", util::encode(hash.as_bytes()));
+                        debug!("not found {}", hash);
                         write_response(&mut writer, &mut out_buffer, request.id, Res::NotFound)
                             .await?;
 
@@ -366,7 +366,7 @@ enum SentStatus {
 
 async fn send_blob<W: AsyncWrite + Unpin + Send + 'static>(
     db: Database,
-    name: bao::Hash,
+    name: Hash,
     mut writer: W,
     buffer: &mut BytesMut,
     id: u64,
@@ -457,7 +457,7 @@ impl From<&std::path::Path> for DataSource {
 ///
 /// If the size of the file is changed while this is running, an error will be
 /// returned.
-fn compute_outboard(path: PathBuf) -> anyhow::Result<(blake3::Hash, Vec<u8>)> {
+fn compute_outboard(path: PathBuf) -> anyhow::Result<(Hash, Vec<u8>)> {
     let file = std::fs::File::open(path)?;
     let len = file.metadata()?.len();
     // compute outboard size so we can pre-allocate the buffer.
@@ -482,12 +482,13 @@ fn compute_outboard(path: PathBuf) -> anyhow::Result<(blake3::Hash, Vec<u8>)> {
     ensure!(len == len2, "file changed during encoding");
     // this flips the outboard encoding from post-order to pre-order
     let hash = encoder.finalize()?;
-    anyhow::Ok((hash, outboard))
+
+    Ok((hash.into(), outboard))
 }
 
 /// Creates a database of blobs (stored in outboard storage) and Collections, stored in memory.
 /// Returns a the hash of the collection created by the given list of DataSources
-pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Database, bao::Hash)> {
+pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Database, Hash)> {
     // +1 is for the collection itself
     let mut db = HashMap::with_capacity(data_sources.len() + 1);
     let mut blobs = Vec::with_capacity(data_sources.len());
@@ -546,7 +547,8 @@ pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Databas
     let mut buffer = BytesMut::zeroed(blobs_encoded_size_estimate + 1024);
     let data = postcard::to_slice(&c, &mut buffer)?;
     let (outboard, hash) = bao::encode::outboard(&data);
-    println!("Collection: {}\n", util::encode(hash.as_bytes()));
+    let hash = Hash::from(hash);
+    println!("Collection: {}\n", hash);
     for el in db.values() {
         if let BlobOrCollection::Blob(blob) = el {
             println!("- {}: {} bytes", blob.path.display(), blob.size);
@@ -588,8 +590,7 @@ async fn write_response<W: AsyncWrite + Unpin>(
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Ticket {
     /// The hash to retrieve.
-    #[serde(with = "crate::protocol::serde_hash")]
-    pub hash: bao::Hash,
+    pub hash: Hash,
     /// The peer ID identifying the provider.
     pub peer: PeerId,
     /// The socket address the provider is listening on.
@@ -627,6 +628,7 @@ mod tests {
     #[test]
     fn test_ticket_base64_roundtrip() {
         let (_encoded, hash) = bao::encode::encode(b"hi there");
+        let hash = Hash::from(hash);
         let peer = PeerId::from(Keypair::generate().public());
         let addr = SocketAddr::from_str("127.0.0.1:1234").unwrap();
         let token = AuthToken::generate();
@@ -649,6 +651,7 @@ mod tests {
         let dir: PathBuf = testdir!();
         let mut expect_blobs = vec![];
         let (_, hash) = bao::encode::outboard(vec![]);
+        let hash = Hash::from(hash);
 
         // DataSource::File
         let foo = dir.join("foo");

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -548,7 +548,7 @@ pub async fn create_collection(data_sources: Vec<DataSource>) -> Result<(Databas
     let data = postcard::to_slice(&c, &mut buffer)?;
     let (outboard, hash) = bao::encode::outboard(&data);
     let hash = Hash::from(hash);
-    println!("Collection: {}\n", hash);
+    println!("Collection: {hash}\n");
     for el in db.values() {
         if let BlobOrCollection::Blob(blob) = el {
             println!("- {}: {} bytes", blob.path.display(), blob.size);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,12 @@
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+use anyhow::ensure;
 use base64::{engine::general_purpose, Engine as _};
+use postcard::experimental::max_size::MaxSize;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 /// Encode the given buffer into Base64 URL SAFE without padding.
 pub fn encode(buf: impl AsRef<[u8]>) -> String {
@@ -8,4 +16,118 @@ pub fn encode(buf: impl AsRef<[u8]>) -> String {
 /// Decode the given buffer from Base64 URL SAFE without padding.
 pub fn decode(buf: impl AsRef<str>) -> Result<Vec<u8>, base64::DecodeError> {
     general_purpose::URL_SAFE_NO_PAD.decode(buf.as_ref())
+}
+
+/// Hash type used throught.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+pub struct Hash(blake3::Hash);
+
+impl Hash {
+    /// Calculate the hash of the provide bytes.
+    pub fn new(buf: impl AsRef<[u8]>) -> Self {
+        let val = blake3::hash(buf.as_ref());
+        Hash(val)
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl From<Hash> for blake3::Hash {
+    fn from(value: Hash) -> Self {
+        value.0
+    }
+}
+
+impl From<blake3::Hash> for Hash {
+    fn from(value: blake3::Hash) -> Self {
+        Hash(value)
+    }
+}
+
+impl From<[u8; 32]> for Hash {
+    fn from(value: [u8; 32]) -> Self {
+        Hash(blake3::Hash::from(value))
+    }
+}
+
+impl Display for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", encode(self.0.as_bytes()))
+    }
+}
+
+impl FromStr for Hash {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut arr = [0u8; 32];
+        let val = decode(s)?;
+        ensure!(
+            val.len() == 32,
+            "invalid byte length, expected 32, got {}",
+            val.len()
+        );
+        arr.copy_from_slice(&val);
+        let hash = blake3::Hash::from(arr);
+
+        Ok(Hash(hash))
+    }
+}
+
+impl Serialize for Hash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.0.as_bytes())
+    }
+}
+
+impl<'de> Deserialize<'de> for Hash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(HashVisitor)
+    }
+}
+
+struct HashVisitor;
+
+impl<'de> de::Visitor<'de> for HashVisitor {
+    type Value = Hash;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "an array of 32 bytes containing hash data")
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let bytes: [u8; 32] = v.try_into().map_err(E::custom)?;
+        Ok(Hash::from(bytes))
+    }
+}
+
+impl MaxSize for Hash {
+    const POSTCARD_MAX_SIZE: usize = 32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash() {
+        let data = b"hello world";
+        let hash = Hash::new(data);
+
+        let encoded = hash.to_string();
+        assert_eq!(encoded.parse::<Hash>().unwrap(), hash);
+    }
 }


### PR DESCRIPTION
- avoids relying on blake3::Hash as a type in the public api
- ensures consistent encoding and decoding
- fixes bug where hex decoding was expected in the UI