### PR TITLE
Make Provider a Future, remove Provider::join

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ mod tests {
         .await?;
 
         provider.abort();
-        let _ = provider.join().await;
+        provider.await.ok(); // .abort() makes this a Result::Err
 
         let events = events_task.await.unwrap();
         assert_eq!(events.len(), 3);

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() -> Result<()> {
             out_writer
                 .println(format!("All-in-one ticket: {}", provider.ticket(hash)))
                 .await;
-            provider.join().await?;
+            provider.await?;
 
             // Drop tempath to signal it can be destroyed
             drop(tmp_path);

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -35,9 +35,9 @@ pub type Database = Arc<HashMap<Hash, BlobOrCollection>>;
 /// You must supply a database which can be created using [`create_collection`], everything else is
 /// optional.  Finally you can create and run the provider by calling [`Builder::spawn`].
 ///
-/// The returned [`Provider`] provides [`Provider::join`] to wait for the spawned task.
-/// Currently it needs to be aborted using [`Provider::abort`], graceful shutdown will be
-/// implemented in the immediate future.
+/// The returned [`Provider`] is awaitable to know when it finishes.  Currently it needs to
+/// be aborted using [`Provider::abort`], graceful shutdown will be implemented in the
+/// future.
 #[derive(Debug)]
 pub struct Builder {
     bind_addr: SocketAddr,


### PR DESCRIPTION
This removes the consuming Provider::join method and makes Provider impl a
Future directly.  This mirrors how a JoinHandle for a tokio task
behaves, which is what this also kind off is.

Primarily this allowes for the await-completion operation to be
cancelable and re-entrant.  This is needed to be able to await
completion of the task in a loop, repeatedly calling tokio::select!
with it.