### PR TITLE
Add newtype wrapper for Hash that is compatible with Cid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +406,26 @@ name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "der"
@@ -892,6 +918,17 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -1650,11 +1687,13 @@ dependencies = [
  "bytes",
  "clap",
  "console",
+ "data-encoding",
  "der",
  "ed25519-dalek",
  "futures",
  "hex",
  "indicatif",
+ "multibase",
  "postcard",
  "proptest",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ blake3 = "1.3.3"
 bytes = "1"
 clap = { version = "4", features = ["derive"], optional = true }
 console = { version = "0.15.5", optional = true }
+data-encoding = "2.3.3"
 der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
+multibase = "0.9.1"
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = "0.9.3"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ blake3 = "1.3.3"
 bytes = "1"
 clap = { version = "4", features = ["derive"], optional = true }
 console = { version = "0.15.5", optional = true }
-data-encoding = "2.3.3"
+data-encoding = { version = "2.3.3", optional = true }
 der = { version = "0.6", features = ["alloc", "derive"] }
 ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.25"
 indicatif = { version = "0.17", features = ["tokio"], optional = true }
-multibase = "0.9.1"
+multibase = { version = "0.9.1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = "0.9.3"
 rand = "0.7"
@@ -50,7 +50,7 @@ testdir = "0.7.1"
 
 [features]
 default = ["cli"]
-cli = ["clap", "console", "indicatif"]
+cli = ["clap", "console", "indicatif", "data-encoding", "multibase"]
 
 [[bin]]
 name = "sendme"

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ impl OutWriter {
 
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Blake3Cid(Hash);
+struct Blake3Cid(Hash);
 
 const CID_PREFIX: [u8; 4] = [
     0x01, // version
@@ -117,11 +117,11 @@ impl Blake3Cid {
         Blake3Cid(hash)
     }
 
-    pub fn hash(&self) -> &Hash {
+    pub fn as_hash(&self) -> &Hash {
         &self.0
     }
 
-    pub fn into_bytes(&self) -> [u8; 36] {
+    pub fn as_bytes(&self) -> [u8; 36] {
         let hash: [u8; 32] = self.0.as_ref().try_into().unwrap();
         let mut res = [0u8; 36];
         res[0..4].copy_from_slice(&CID_PREFIX);
@@ -147,7 +147,7 @@ impl fmt::Display for Blake3Cid {
         // result will be 58 bytes plus prefix
         let mut res = [b'b'; 59];
         // write the encoded bytes
-        data_encoding::BASE32_NOPAD.encode_mut(&self.into_bytes(), &mut res[1..]);
+        data_encoding::BASE32_NOPAD.encode_mut(&self.as_bytes(), &mut res[1..]);
         // convert to string, this is guaranteed to succeed
         let t = std::str::from_utf8_mut(res.as_mut()).unwrap();
         // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
@@ -215,7 +215,7 @@ async fn main() -> Result<()> {
             }
             let token =
                 AuthToken::from_str(&token).context("Wrong format for authentication token")?;
-            get_interactive(*hash.hash(), opts, token, out).await?;
+            get_interactive(*hash.as_hash(), opts, token, out).await?;
         }
         Commands::GetTicket { out, ticket } => {
             let Ticket {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, str::FromStr};
+use std::{fmt, net::SocketAddr, path::PathBuf, str::FromStr};
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
@@ -10,7 +10,7 @@ use sendme::protocol::AuthToken;
 use sendme::provider::Ticket;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 use sendme::{get, provider, Hash, Keypair, PeerId};
 
@@ -44,7 +44,7 @@ enum Commands {
     #[clap(about = "Fetch the data from the hash")]
     Get {
         /// The root hash to retrieve.
-        hash: Hash,
+        hash: Blake3Cid,
         /// PeerId of the provider.
         #[clap(long, short)]
         peer: PeerId,
@@ -101,13 +101,93 @@ impl OutWriter {
     }
 }
 
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Blake3Cid(Hash);
+
+const CID_PREFIX: [u8; 4] = [0x01, 0x55, 0x1e, 0x20];
+
+impl Blake3Cid {
+    pub fn new(hash: Hash) -> Self {
+        Blake3Cid(hash)
+    }
+
+    pub fn hash(&self) -> &Hash {
+        &self.0
+    }
+
+    pub fn into_bytes(&self) -> [u8; 36] {
+        let hash: [u8; 32] = self.0.as_ref().try_into().unwrap();
+        let mut res = [0u8; 36];
+        res[0..4].copy_from_slice(&CID_PREFIX);
+        res[4..36].copy_from_slice(&hash);
+        res
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            bytes.len() == 36,
+            "invalid cid length, expected 36, got {}",
+            bytes.len()
+        );
+        anyhow::ensure!(bytes[0..4] == CID_PREFIX, "invalid cid prefix");
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&bytes[4..36]);
+        Ok(Blake3Cid(Hash::from(hash)))
+    }
+}
+
+impl fmt::Display for Blake3Cid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // result will be 58 bytes plus prefix
+        let mut res = [b'b'; 59];
+        // write the encoded bytes
+        data_encoding::BASE32_NOPAD.encode_mut(&self.into_bytes(), &mut res[1..]);
+        // convert to string, this is guaranteed to succeed
+        let t = std::str::from_utf8_mut(res.as_mut()).unwrap();
+        // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
+        t.make_ascii_lowercase();
+        // write the str, no allocations
+        f.write_str(t)
+    }
+}
+
+impl FromStr for Blake3Cid {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let sb = s.as_bytes();
+        if sb.len() == 59 && sb[0] == b'b' {
+            // this is a base32 encoded cid, we can decode it directly
+            let mut t = [0u8; 58];
+            t.copy_from_slice(&sb[1..]);
+            // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
+            std::str::from_utf8_mut(t.as_mut())
+                .unwrap()
+                .make_ascii_uppercase();
+            // decode the bytes
+            let mut res = [0u8; 36];
+            data_encoding::BASE32_NOPAD
+                .decode_mut(&t, &mut res)
+                .map_err(|_e| anyhow::anyhow!("invalid base32"))?;
+            // convert to cid, this will check the prefix
+            Self::from_bytes(&res)
+        } else {
+            // if we want to support all the weird multibase prefixes, we have no choice
+            // but to use the multibase crate
+            let (_base, bytes) = multibase::decode(s)?;
+            Self::from_bytes(bytes.as_ref())
+        }
+    }
+}
+
 const PROGRESS_STYLE: &str =
     "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})";
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::registry()
-        .with(fmt::layer().with_writer(std::io::stderr))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
         .with(EnvFilter::from_default_env())
         .init();
 
@@ -130,7 +210,7 @@ async fn main() -> Result<()> {
             }
             let token =
                 AuthToken::from_str(&token).context("Wrong format for authentication token")?;
-            get_interactive(hash, opts, token, out).await?;
+            get_interactive(*hash.hash(), opts, token, out).await?;
         }
         Commands::GetTicket { out, ticket } => {
             let Ticket {
@@ -185,6 +265,12 @@ async fn main() -> Result<()> {
             };
 
             let (db, hash) = provider::create_collection(sources).await?;
+
+            println!("Collection: {}\n", Blake3Cid::new(hash));
+            for (_, path, size) in db.blobs() {
+                println!("- {}: {} bytes", path.display(), size);
+            }
+            println!();
             let mut builder = provider::Provider::builder(db).keypair(keypair);
             if let Some(addr) = addr {
                 builder = builder.bind_addr(addr);

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,12 @@ impl OutWriter {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Blake3Cid(Hash);
 
-const CID_PREFIX: [u8; 4] = [0x01, 0x55, 0x1e, 0x20];
+const CID_PREFIX: [u8; 4] = [
+    0x01, // version
+    0x55, // raw codec
+    0x1e, // hash function, blake3
+    0x20, // hash size, 32 bytes
+];
 
 impl Blake3Cid {
     pub fn new(hash: Hash) -> Self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,6 +118,86 @@ impl MaxSize for Hash {
     const POSTCARD_MAX_SIZE: usize = 32;
 }
 
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Blake3Cid(Hash);
+
+const CID_PREFIX: [u8; 4] = [0x01, 0x55, 0x1e, 0x20];
+
+impl Blake3Cid {
+    pub fn new(hash: Hash) -> Self {
+        Blake3Cid(hash)
+    }
+
+    pub fn hash(&self) -> &Hash {
+        &self.0
+    }
+
+    pub fn into_bytes(&self) -> [u8; 36] {
+        let hash: [u8; 32] = self.0 .0.into();
+        let mut res = [0u8; 36];
+        res[0..4].copy_from_slice(&CID_PREFIX);
+        res[4..36].copy_from_slice(&hash);
+        res
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        ensure!(
+            bytes.len() == 36,
+            "invalid cid length, expected 36, got {}",
+            bytes.len()
+        );
+        ensure!(bytes[0..4] == CID_PREFIX, "invalid cid prefix");
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&bytes[4..36]);
+        Ok(Blake3Cid(Hash::from(hash)))
+    }
+}
+
+impl Display for Blake3Cid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // result will be 58 bytes plus prefix
+        let mut res = [b'b'; 59];
+        // write the encoded bytes
+        data_encoding::BASE32_NOPAD.encode_mut(&self.into_bytes(), &mut res[1..]);
+        // convert to string, this is guaranteed to succeed
+        let t = std::str::from_utf8_mut(res.as_mut()).unwrap();
+        // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
+        t.make_ascii_lowercase();
+        // write the str, no allocations
+        f.write_str(t)
+    }
+}
+
+impl FromStr for Blake3Cid {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let sb = s.as_bytes();
+        if sb.len() == 59 && sb[0] == b'b' {
+            // this is a base32 encoded cid, we can decode it directly
+            let mut t = [0u8; 58];
+            t.copy_from_slice(&sb[1..]);
+            // hack since data_encoding doesn't have BASE32LOWER_NOPAD as a const
+            std::str::from_utf8_mut(t.as_mut())
+                .unwrap()
+                .make_ascii_uppercase();
+            // decode the bytes
+            let mut res = [0u8; 36];
+            data_encoding::BASE32_NOPAD
+                .decode_mut(&t, &mut res)
+                .map_err(|_e| anyhow::anyhow!("invalid base32"))?;
+            // convert to cid, this will check the prefix
+            Self::from_bytes(&res)
+        } else {
+            // if we want to support all the weird multibase prefixes, we have no choice
+            // but to use the multibase crate
+            let (_base, bytes) = multibase::decode(s)?;
+            Self::from_bytes(bytes.as_ref())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +209,25 @@ mod tests {
 
         let encoded = hash.to_string();
         assert_eq!(encoded.parse::<Hash>().unwrap(), hash);
+    }
+
+    #[test]
+    fn test_cid() {
+        let expected = "bafkr4igxjga67jykbseaxdmmdgc5a5o3zp3htom2l6mrjznk7fvyggu6eq";
+        let data = b"hello world";
+        let hash = Hash::new(data);
+        let cid = Blake3Cid::new(hash);
+        // test to_string and parse from base32lower
+        assert_eq!(cid.to_string(), expected.to_string());
+        assert_eq!(Blake3Cid::from_str(expected).unwrap(), cid);
+        // test parse from other multibase encodings
+        for encoding in [
+            multibase::Base::Base58Btc,
+            multibase::Base::Base64,
+            multibase::Base::Base32Upper,
+        ] {
+            let encoded = multibase::encode(encoding, cid.into_bytes());
+            assert_eq!(Blake3Cid::from_str(&encoded).unwrap(), cid);
+        }
     }
 }


### PR DESCRIPTION
Implements n0-computer/iroh#762

Spent some effort making the fast path to_string and parse 0 alloc by directly using the data-encoding crate. Not sure if we need the multibase crate, but to be really compatible with cid I guess we do.

So what I don't know is where I am supposed to use this. Replace to_string etc. of sendme::util::Hash? Or just in selected places?

I put it all in main for now.