### PR TITLE
feat: Do not error when the provider closes the connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,19 @@ mod tests {
         sync::{atomic::AtomicUsize, Arc},
     };
 
-    use crate::tls::PeerId;
-    use crate::{protocol::AuthToken, util::Hash};
-
-    use super::*;
-    use anyhow::Result;
+    use anyhow::{anyhow, Context, Result};
     use rand::RngCore;
     use testdir::testdir;
-    use tokio::io::AsyncReadExt;
+    use tokio::fs;
+    use tokio::io::{self, AsyncReadExt};
+
+    use crate::{protocol::AuthToken, provider::Event, util::Hash};
+    use crate::{
+        provider::{create_collection, Provider},
+        tls::PeerId,
+    };
+
+    use super::*;
 
     #[tokio::test]
     async fn basics() -> Result<()> {
@@ -252,5 +257,66 @@ mod tests {
         assert_eq!(events.len(), 3);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_server_close() {
+        // Prepare a Provider transferring a file.
+        let dir = testdir!();
+        let src = dir.join("src");
+        fs::write(&src, "hello there").await.unwrap();
+        let (db, hash) = create_collection(vec![src.into()]).await.unwrap();
+        let mut provider = Provider::builder(db)
+            .bind_addr("127.0.0.1:0".parse().unwrap())
+            .spawn()
+            .unwrap();
+        let auth_token = provider.auth_token();
+        let provider_addr = provider.listen_addr();
+
+        // This tasks closes the connection on the provider side as soon as the transfer
+        // completes.
+        let supervisor = tokio::spawn(async move {
+            let mut events = provider.subscribe();
+            loop {
+                tokio::select! {
+                    biased;
+                    res = &mut provider => break res.context("provider failed"),
+                    maybe_event = events.recv() => {
+                        match maybe_event {
+                            Ok(event) => {
+                                match event {
+                                    Event::TransferCompleted { .. } => provider.shutdown(),
+                                    Event::TransferAborted { .. } => {
+                                        break Err(anyhow!("transfer aborted"));
+                                    }
+                                    _ => (),
+                                }
+                            }
+                            Err(err) => break Err(anyhow!("event failed: {err:#}")),
+                        }
+                    }
+                }
+            }
+        });
+
+        get::run(
+            hash,
+            auth_token,
+            get::Options {
+                addr: provider_addr,
+                peer_id: None,
+            },
+            || async move { Ok(()) },
+            |_collection| async move { Ok(()) },
+            |_hash, mut stream, _name| async move {
+                io::copy(&mut stream, &mut io::sink()).await?;
+                Ok(stream)
+            },
+        )
+        .await
+        .unwrap();
+
+        // Unwrap the JoinHandle, then the result of the Provider
+        supervisor.await.unwrap().unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,10 @@ mod tests {
     use tokio::fs;
     use tokio::io::{self, AsyncReadExt};
 
-    use crate::{protocol::AuthToken, provider::Event, util::Hash};
-    use crate::{
-        provider::{create_collection, Provider},
-        tls::PeerId,
-    };
+    use crate::protocol::AuthToken;
+    use crate::provider::{create_collection, Event, Provider};
+    use crate::tls::PeerId;
+    use crate::util::Hash;
 
     use super::*;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -228,7 +228,6 @@ pub(crate) enum Closed {
     /// Used implicitly when a [`quinn::RecvStream`] is dropped without explicit call to
     /// [`quinn::RecvStream::stop`].  We don't use this explicitly but this is here as
     /// documentation as to what happened to `0`.
-    #[allow(dead_code)]
     StreamDropped = 0,
     /// The provider is terminating.
     ///
@@ -267,6 +266,7 @@ impl TryFrom<VarInt> for Closed {
 
     fn try_from(value: VarInt) -> std::result::Result<Self, Self::Error> {
         match value.into_inner() {
+            0 => Ok(Self::StreamDropped),
             1 => Ok(Self::ProviderTerminating),
             2 => Ok(Self::RequestReceived),
             val => Err(UnknownErrorCode(val)),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use anyhow::{ensure, Result};
 use bytes::{Bytes, BytesMut};
 use postcard::experimental::max_size::MaxSize;
+use quinn::VarInt;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tracing::debug;
@@ -209,6 +210,67 @@ impl FromStr for AuthToken {
             .try_into()
             .map_err(|v: Vec<u8>| AuthTokenParseError::Length(v.len()))?;
         Ok(AuthToken { bytes })
+    }
+}
+
+/// Reasons to close connections or stop streams.
+///
+/// A QUIC **connection** can be *closed* and a **stream** can request the other side to
+/// *stop* sending data.  Both these associate and `error_code` with that operation, closing
+/// also adds a `reason` as some arbitrary bytes.
+///
+/// This enum exists so we have a single namespace for `error_code`s used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub(crate) enum Closed {
+    /// The [`quinn::RecvStream`] was dropped.
+    ///
+    /// Used implicitly when a [`quinn::RecvStream`] is dropped without explicit call to
+    /// [`quinn::RecvStream::stop`].  We don't use this explicitly but this is here as
+    /// documentation as to what happened to `0`.
+    #[allow(dead_code)]
+    StreamDropped = 0,
+    /// The provider is terminating.
+    ///
+    /// When a provider terminates all connections and associated streams are closed.
+    ProviderTerminating = 1,
+    /// The provider has received the request.
+    ///
+    /// Only a single request is allowed on a stream, once this request is received the
+    /// provider will close its [`quinn::RecvStream`] with this error code.
+    RequestReceived = 2,
+}
+
+impl Closed {
+    pub fn reason(&self) -> &'static [u8] {
+        match self {
+            Closed::StreamDropped => &b"stream dropped"[..],
+            Closed::ProviderTerminating => &b"provider terminating"[..],
+            Closed::RequestReceived => &b"request received"[..],
+        }
+    }
+}
+
+impl From<Closed> for VarInt {
+    fn from(source: Closed) -> Self {
+        VarInt::from(source as u16)
+    }
+}
+
+/// Unknown error_code, can not be converted into [`Closed`].
+#[derive(thiserror::Error, Debug)]
+#[error("Unknown error_code: {0}")]
+pub(crate) struct UnknownErrorCode(u64);
+
+impl TryFrom<VarInt> for Closed {
+    type Error = UnknownErrorCode;
+
+    fn try_from(value: VarInt) -> std::result::Result<Self, Self::Error> {
+        match value.into_inner() {
+            1 => Ok(Self::ProviderTerminating),
+            2 => Ok(Self::RequestReceived),
+            val => Err(UnknownErrorCode(val)),
+        }
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -216,7 +216,7 @@ impl FromStr for AuthToken {
 /// Reasons to close connections or stop streams.
 ///
 /// A QUIC **connection** can be *closed* and a **stream** can request the other side to
-/// *stop* sending data.  Both these associate and `error_code` with that operation, closing
+/// *stop* sending data.  Both closing and stopping have an associated `error_code`, closing
 /// also adds a `reason` as some arbitrary bytes.
 ///
 /// This enum exists so we have a single namespace for `error_code`s used.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -419,6 +419,7 @@ async fn handle_stream(
                                 break;
                             }
                         }
+                        writer.finish().await?;
                         let _ = events.send(Event::TransferCompleted {
                             connection_id,
                             request_id: request.id,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -30,7 +30,9 @@ use tracing::{debug, debug_span, warn};
 use tracing_futures::Instrument;
 
 use crate::blobs::{Blob, Collection};
-use crate::protocol::{read_lp, write_lp, AuthToken, Handshake, Request, Res, Response, VERSION};
+use crate::protocol::{
+    read_lp, write_lp, AuthToken, Closed, Handshake, Request, Res, Response, VERSION,
+};
 use crate::tls::{self, Keypair, PeerId};
 use crate::util::{self, Hash};
 
@@ -176,7 +178,8 @@ impl Builder {
         // connections: Operations will immediately fail with
         // ConnectionError::LocallyClosed.  All streams are interrupted, this is not
         // graceful.
-        server.close(1u16.into(), b"provider terminating");
+        let error_code = Closed::ProviderTerminating;
+        server.close(error_code.into(), error_code.reason());
     }
 }
 
@@ -359,91 +362,80 @@ async fn handle_stream(
         bail!("no valid handshake received");
     }
 
-    // 2. Decode protocol messages.
-    loop {
-        debug!("reading request");
-        match read_lp::<_, Request>(&mut reader, &mut in_buffer).await? {
-            Some((request, _size)) => {
-                let hash = request.name;
-                debug!("got request({})", request.id);
-                let _ = events.send(Event::RequestReceived {
-                    connection_id,
-                    request_id: request.id,
-                    hash,
-                });
+    // 2. Decode the request.
+    debug!("reading request");
+    let request = read_lp::<_, Request>(&mut reader, &mut in_buffer).await?;
+    reader.stop(Closed::RequestReceived.into())?;
+    if let Some((request, _size)) = request {
+        let hash = request.name;
+        debug!("got request({})", request.id);
+        let _ = events.send(Event::RequestReceived {
+            connection_id,
+            request_id: request.id,
+            hash,
+        });
 
-                match db.get(&hash) {
-                    // We only respond to requests for collections, not individual blobs
-                    Some(BlobOrCollection::Collection((outboard, data))) => {
-                        debug!("found collection {}", hash);
+        match db.get(&hash) {
+            // We only respond to requests for collections, not individual blobs
+            Some(BlobOrCollection::Collection((outboard, data))) => {
+                debug!("found collection {}", hash);
 
-                        let mut extractor = SliceExtractor::new_outboard(
-                            std::io::Cursor::new(&data[..]),
-                            std::io::Cursor::new(&outboard[..]),
-                            0,
-                            data.len() as u64,
-                        );
-                        let encoded_size: usize = bao::encode::encoded_size(data.len() as u64)
-                            .try_into()
-                            .unwrap();
-                        let mut encoded = Vec::with_capacity(encoded_size);
-                        extractor.read_to_end(&mut encoded)?;
+                let mut extractor = SliceExtractor::new_outboard(
+                    std::io::Cursor::new(&data[..]),
+                    std::io::Cursor::new(&outboard[..]),
+                    0,
+                    data.len() as u64,
+                );
+                let encoded_size: usize = bao::encode::encoded_size(data.len() as u64)
+                    .try_into()
+                    .unwrap();
+                let mut encoded = Vec::with_capacity(encoded_size);
+                extractor.read_to_end(&mut encoded)?;
 
-                        let c: Collection = postcard::from_bytes(data)?;
+                let c: Collection = postcard::from_bytes(data)?;
 
-                        // TODO: we should check if the blobs referenced in this container
-                        // actually exist in this provider before returning `FoundCollection`
-                        write_response(
-                            &mut writer,
-                            &mut out_buffer,
-                            request.id,
-                            Res::FoundCollection {
-                                total_blobs_size: c.total_blobs_size,
-                            },
-                        )
-                        .await?;
+                // TODO: we should check if the blobs referenced in this container
+                // actually exist in this provider before returning `FoundCollection`
+                write_response(
+                    &mut writer,
+                    &mut out_buffer,
+                    request.id,
+                    Res::FoundCollection {
+                        total_blobs_size: c.total_blobs_size,
+                    },
+                )
+                .await?;
 
-                        let mut data = BytesMut::from(&encoded[..]);
-                        writer.write_buf(&mut data).await?;
-                        for blob in c.blobs {
-                            let (status, writer1) = send_blob(
-                                db.clone(),
-                                blob.hash,
-                                writer,
-                                &mut out_buffer,
-                                request.id,
-                            )
+                let mut data = BytesMut::from(&encoded[..]);
+                writer.write_buf(&mut data).await?;
+                for blob in c.blobs {
+                    let (status, writer1) =
+                        send_blob(db.clone(), blob.hash, writer, &mut out_buffer, request.id)
                             .await?;
-                            writer = writer1;
-                            if SentStatus::NotFound == status {
-                                break;
-                            }
-                        }
-                        writer.finish().await?;
-                        let _ = events.send(Event::TransferCompleted {
-                            connection_id,
-                            request_id: request.id,
-                        });
-                    }
-                    _ => {
-                        debug!("not found {}", hash);
-                        write_response(&mut writer, &mut out_buffer, request.id, Res::NotFound)
-                            .await?;
-
-                        let _ = events.send(Event::TransferAborted {
-                            connection_id,
-                            request_id: request.id,
-                        });
+                    writer = writer1;
+                    if SentStatus::NotFound == status {
+                        break;
                     }
                 }
 
+                writer.finish().await?;
+                let _ = events.send(Event::TransferCompleted {
+                    connection_id,
+                    request_id: request.id,
+                });
                 debug!("finished response");
             }
-            None => {
-                break;
+            _ => {
+                debug!("not found {}", hash);
+                write_response(&mut writer, &mut out_buffer, request.id, Res::NotFound).await?;
+                writer.finish().await?;
+                // TODO: If the connection drops mid-way we also need to emit this!
+                let _ = events.send(Event::TransferAborted {
+                    connection_id,
+                    request_id: request.id,
+                });
             }
         }
-        in_buffer.clear();
     }
 
     Ok(())


### PR DESCRIPTION
This makes it so that the provider is allowed to close the connection
after a transfer is completed, without the getter resulting in an
error.

It modifies the provider to only emit the transfer completed once the
data has actually reached the client.