### PR TITLE
Fix QUIC stream completion

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -158,7 +158,6 @@ where
         let used = postcard::to_slice(&req, &mut out_buffer)?;
         write_lp(&mut writer, used).await?;
     }
-    dbg!(writer.finish().await)?;
     drop(writer);
 
     // 3. Read response

--- a/src/get.rs
+++ b/src/get.rs
@@ -158,6 +158,7 @@ where
         let used = postcard::to_slice(&req, &mut out_buffer)?;
         write_lp(&mut writer, used).await?;
     }
+    writer.finish().await?;
     drop(writer);
 
     // 3. Read response

--- a/src/get.rs
+++ b/src/get.rs
@@ -158,7 +158,7 @@ where
         let used = postcard::to_slice(&req, &mut out_buffer)?;
         write_lp(&mut writer, used).await?;
     }
-    writer.finish().await?;
+    dbg!(writer.finish().await)?;
     drop(writer);
 
     // 3. Read response

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -235,8 +235,8 @@ pub(crate) enum Closed {
     ProviderTerminating = 1,
     /// The provider has received the request.
     ///
-    /// Only a single request is allowed on a stream, once this request is received the
-    /// provider will close its [`quinn::RecvStream`] with this error code.
+    /// Only a single request is allowed on a stream, if more data is received after this a
+    /// provider may send this error code in a STOP_STREAM frame.
     RequestReceived = 2,
 }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -365,7 +365,6 @@ async fn handle_stream(
     // 2. Decode the request.
     debug!("reading request");
     let request = read_lp::<_, Request>(&mut reader, &mut in_buffer).await?;
-    reader.stop(Closed::RequestReceived.into())?;
     if let Some((request, _size)) = request {
         let hash = request.name;
         debug!("got request({})", request.id);


### PR DESCRIPTION
Sending a STOP_STREAM frame from the receiver is the way for a receiver to go to the reset state.  It involves sending an extra frame, the receiver will then send its own RESET_STREAM frame and the stream is considered ended in an error state.

Instead the right way to end a stream is to set the FIN bit on the final STREAM frame, ideally not even resulting in an extra frame or packet sent.  This is done on the sender side.