### PR TITLE
start debugging earyl close

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -229,6 +229,12 @@ where
                     }
                 }
 
+                let chunk = reader.read_chunk(8, false).await?;
+                ensure!(
+                    chunk.is_none(),
+                    "received unexpected data from the provider: {:?}",
+                    chunk
+                );
                 // Shut down the stream
                 drop(reader);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,6 @@ mod tests {
         .await
         .unwrap();
 
-        println!("wait for supervisor");
         // Unwrap the JoinHandle, then the result of the Provider
         tokio::time::timeout(Duration::from_secs(10), supervisor)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
                     biased;
                     res = &mut provider => break res.context("provider failed"),
                     maybe_event = events.recv() => {
-                        match dbg!(maybe_event) {
+                        match maybe_event {
                             Ok(event) => {
                                 match event {
                                     Event::TransferCompleted { .. } => provider.shutdown(),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -408,7 +408,8 @@ async fn handle_stream(
 
                 let mut data = BytesMut::from(&encoded[..]);
                 writer.write_buf(&mut data).await?;
-                for blob in c.blobs {
+                for (i, blob) in c.blobs.iter().enumerate() {
+                    debug!("writing blob {}/{}", i, c.blobs.len());
                     let (status, writer1) =
                         send_blob(db.clone(), blob.hash, writer, &mut out_buffer, request.id)
                             .await?;
@@ -417,7 +418,7 @@ async fn handle_stream(
                         break;
                     }
                 }
-
+                debug!("all blobs written");
                 writer.finish().await?;
                 let _ = events.send(Event::TransferCompleted {
                     connection_id,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -418,6 +418,7 @@ async fn handle_stream(
                         break;
                     }
                 }
+
                 writer.finish().await?;
                 let _ = events.send(Event::TransferCompleted {
                     connection_id,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -366,6 +366,10 @@ async fn handle_stream(
     // 2. Decode the request.
     debug!("reading request");
     let request = read_lp::<_, Request>(&mut reader, &mut in_buffer).await?;
+    ensure!(
+        reader.read_chunk(8, false).await?.is_none(),
+        "Extra data past request"
+    );
     if let Some((request, _size)) = request {
         let hash = request.name;
         debug!("got request({})", request.id);

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -418,7 +418,6 @@ async fn handle_stream(
                         break;
                     }
                 }
-                debug!("all blobs written");
                 writer.finish().await?;
                 let _ = events.send(Event::TransferCompleted {
                     connection_id,


### PR DESCRIPTION
When finished with a stream you have to read to EOF.  Sometimes the sender could be sending the FIN bit in an empty STREAM frame after all the data is sent, if the receiver did not read EOF in this case the receiver will still implicitly call `RecvStream::stop` on drop, making the stream error for the sender.

----

running a couple times: should reproduce the issue
```
> RUST_LOG=debug cargo test server_close -- --nocapture
```