### PR TITLE
fix: ensure we emit `TransferAborted` event if anything goes wrong during the transfer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,10 @@ mod tests {
                         events.push(event);
                         break;
                     }
+                    Event::TransferAborted { .. } => {
+                        events.push(event);
+                        break;
+                    }
                     _ => events.push(event),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,11 +211,7 @@ mod tests {
             let mut events = Vec::new();
             while let Ok(event) = provider_events.recv().await {
                 match event {
-                    Event::TransferCompleted { .. } => {
-                        events.push(event);
-                        break;
-                    }
-                    Event::TransferAborted { .. } => {
+                    Event::TransferCompleted { .. } | Event::TransferAborted { .. } => {
                         events.push(event);
                         break;
                     }
@@ -269,9 +265,16 @@ mod tests {
         provider.shutdown();
         provider.await?;
 
-        assert_eq!(events.len(), 3);
+        assert_events(events);
 
         Ok(())
+    }
+
+    fn assert_events(events: Vec<Event>) {
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], Event::ClientConnected { .. }));
+        assert!(matches!(events[1], Event::RequestReceived { .. }));
+        assert!(matches!(events[2], Event::TransferCompleted { .. }));
     }
 
     fn setup_logging() {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -80,7 +80,7 @@ impl ProgressEmitter {
 ///
 /// This exists so it can be Arc'd into [`ProgressEmitter`] and we can easily have multiple
 /// `Send + Sync` copies of it.  This is used by the
-/// [`ProgressEmitter::ProgressAsyncReader`] to update the progress without intertwining
+/// [`ProgressAsyncReader`] to update the progress without intertwining
 /// lifetimes.
 #[derive(Debug)]
 struct InnerProgressEmitter {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -438,6 +438,7 @@ async fn transfer_collection(
             send_blob(db.clone(), blob.hash, writer, buffer, request_id).await?;
         writer = writer1;
         if SentStatus::NotFound == status {
+            write_response(&mut writer, buffer, request_id, Res::NotFound).await?;
             writer.finish().await?;
             return Ok(status);
         }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -339,7 +339,9 @@ async fn handle_connection(
     .await
 }
 
-/// Read and decode the handshake. Will fail if there is an error while reading, there is a token
+/// Read and decode the handshake.
+///
+/// Will fail if there is an error while reading, there is a token
 /// mismatch, or no valid handshake was received.
 ///
 /// When successful, the reader is still useable after this function and the buffer will be drained of any handshake
@@ -364,7 +366,9 @@ async fn read_handshake<R: AsyncRead + Unpin>(
     Ok(())
 }
 
-/// Read the request from the getter. Will fail if there is an error while reading, if the reader
+/// Read the request from the getter.
+///
+/// Will fail if there is an error while reading, if the reader
 /// contains more data than the Request, or if no valid request is sent.
 ///
 /// When successful, the buffer is empty after this function call.
@@ -381,8 +385,12 @@ async fn read_request(mut reader: quinn::RecvStream, buffer: &mut BytesMut) -> R
     }
 }
 
-/// Transfers the collection data & outboard encoding and then the individual blob data & outboard
-/// encoding, sequentially. Will fail if there is an error writing to the getter or reading from
+/// Transfers the collection & blob data.
+///
+/// First, it transfers the collection data & its associated outboard encoding data. Then it sequentially transfers each individual blob data & its associated outboard
+/// encoding data.
+///
+/// Will fail if there is an error writing to the getter or reading from
 /// the database.
 ///
 /// If a blob from the collection cannot be found in the database, the transfer will gracefully

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -22,7 +22,7 @@ use anyhow::{bail, ensure, Context, Result};
 use bytes::{Bytes, BytesMut};
 use futures::future;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::broadcast;
 use tokio::task::{JoinError, JoinHandle};
 use tokio_util::io::SyncIoBridge;
@@ -338,6 +338,98 @@ async fn handle_connection(
     .await
 }
 
+async fn handshake<R: AsyncRead + Unpin>(
+    mut reader: R,
+    buffer: &mut BytesMut,
+    token: AuthToken,
+) -> Result<()> {
+    if let Some((handshake, size)) = read_lp::<_, Handshake>(&mut reader, buffer).await? {
+        ensure!(
+            handshake.version == VERSION,
+            "expected version {} but got {}",
+            VERSION,
+            handshake.version
+        );
+        ensure!(handshake.token == token, "AuthToken mismatch");
+        let _ = buffer.split_to(size);
+    } else {
+        bail!("no valid handshake received");
+    }
+    Ok(())
+}
+
+async fn decode_request(mut reader: quinn::RecvStream, buffer: &mut BytesMut) -> Result<Request> {
+    let request = read_lp::<_, Request>(&mut reader, buffer).await?;
+    ensure!(
+        reader.read_chunk(8, false).await?.is_none(),
+        "Extra data past request"
+    );
+    if let Some((request, _size)) = request {
+        Ok(request)
+    } else {
+        bail!("No request received");
+    }
+}
+
+async fn transfer_collection(
+    db: Database,
+    mut writer: quinn::SendStream,
+    buffer: &mut BytesMut,
+    request_id: u64,
+    outboard: &Bytes,
+    data: &Bytes,
+) -> Result<()> {
+    // We only respond to requests for collections, not individual blobs
+    let mut extractor = SliceExtractor::new_outboard(
+        std::io::Cursor::new(&data[..]),
+        std::io::Cursor::new(&outboard[..]),
+        0,
+        data.len() as u64,
+    );
+    let encoded_size: usize = abao::encode::encoded_size(data.len() as u64)
+        .try_into()
+        .unwrap();
+    let mut encoded = Vec::with_capacity(encoded_size);
+    extractor.read_to_end(&mut encoded)?;
+
+    let c: Collection = postcard::from_bytes(data)?;
+
+    // TODO: we should check if the blobs referenced in this container
+    // actually exist in this provider before returning `FoundCollection`
+    write_response(
+        &mut writer,
+        buffer,
+        request_id,
+        Res::FoundCollection {
+            total_blobs_size: c.total_blobs_size,
+        },
+    )
+    .await?;
+
+    let mut data = BytesMut::from(&encoded[..]);
+    writer.write_buf(&mut data).await?;
+    for (i, blob) in c.blobs.iter().enumerate() {
+        debug!("writing blob {}/{}", i, c.blobs.len());
+        let (status, writer1) =
+            send_blob(db.clone(), blob.hash, writer, buffer, request_id).await?;
+        writer = writer1;
+        if SentStatus::NotFound == status {
+            break;
+        }
+    }
+
+    writer.finish().await?;
+    debug!("finished response");
+    Ok(())
+}
+
+fn notify_transfer_aborted(events: broadcast::Sender<Event>, connection_id: u64, request_id: u64) {
+    let _ = events.send(Event::TransferAborted {
+        connection_id,
+        request_id,
+    });
+}
+
 async fn handle_stream(
     db: Database,
     token: AuthToken,
@@ -350,99 +442,62 @@ async fn handle_stream(
 
     // 1. Read Handshake
     debug!("reading handshake");
-    if let Some((handshake, size)) = read_lp::<_, Handshake>(&mut reader, &mut in_buffer).await? {
-        ensure!(
-            handshake.version == VERSION,
-            "expected version {} but got {}",
-            VERSION,
-            handshake.version
-        );
-        ensure!(handshake.token == token, "AuthToken mismatch");
-        let _ = in_buffer.split_to(size);
-    } else {
-        bail!("no valid handshake received");
+    if let Err(e) = handshake(&mut reader, &mut in_buffer, token).await {
+        notify_transfer_aborted(events, connection_id, 0);
+        return Err(e);
     }
 
     // 2. Decode the request.
     debug!("reading request");
-    let request = read_lp::<_, Request>(&mut reader, &mut in_buffer).await?;
-    ensure!(
-        reader.read_chunk(8, false).await?.is_none(),
-        "Extra data past request"
-    );
-    if let Some((request, _size)) = request {
-        let hash = request.name;
-        debug!("got request({})", request.id);
-        let _ = events.send(Event::RequestReceived {
-            connection_id,
-            request_id: request.id,
-            hash,
-        });
-
-        match db.get(&hash) {
-            // We only respond to requests for collections, not individual blobs
-            Some(BlobOrCollection::Collection((outboard, data))) => {
-                debug!("found collection {}", hash);
-
-                let mut extractor = SliceExtractor::new_outboard(
-                    std::io::Cursor::new(&data[..]),
-                    std::io::Cursor::new(&outboard[..]),
-                    0,
-                    data.len() as u64,
-                );
-                let encoded_size: usize = abao::encode::encoded_size(data.len() as u64)
-                    .try_into()
-                    .unwrap();
-                let mut encoded = Vec::with_capacity(encoded_size);
-                extractor.read_to_end(&mut encoded)?;
-
-                let c: Collection = postcard::from_bytes(data)?;
-
-                // TODO: we should check if the blobs referenced in this container
-                // actually exist in this provider before returning `FoundCollection`
-                write_response(
-                    &mut writer,
-                    &mut out_buffer,
-                    request.id,
-                    Res::FoundCollection {
-                        total_blobs_size: c.total_blobs_size,
-                    },
-                )
-                .await?;
-
-                let mut data = BytesMut::from(&encoded[..]);
-                writer.write_buf(&mut data).await?;
-                for (i, blob) in c.blobs.iter().enumerate() {
-                    debug!("writing blob {}/{}", i, c.blobs.len());
-                    let (status, writer1) =
-                        send_blob(db.clone(), blob.hash, writer, &mut out_buffer, request.id)
-                            .await?;
-                    writer = writer1;
-                    if SentStatus::NotFound == status {
-                        break;
-                    }
-                }
-
-                writer.finish().await?;
-                let _ = events.send(Event::TransferCompleted {
-                    connection_id,
-                    request_id: request.id,
-                });
-                debug!("finished response");
-            }
-            _ => {
-                debug!("not found {}", hash);
-                write_response(&mut writer, &mut out_buffer, request.id, Res::NotFound).await?;
-                writer.finish().await?;
-                // TODO: If the connection drops mid-way we also need to emit this!
-                let _ = events.send(Event::TransferAborted {
-                    connection_id,
-                    request_id: request.id,
-                });
-            }
+    let request = match decode_request(reader, &mut in_buffer).await {
+        Ok(r) => r,
+        Err(e) => {
+            notify_transfer_aborted(events, connection_id, 0);
+            return Err(e);
         }
+    };
+
+    let hash = request.name;
+    debug!("got request({})", request.id);
+    let _ = events.send(Event::RequestReceived {
+        connection_id,
+        request_id: request.id,
+        hash,
+    });
+
+    // 4. Attempt to find hash
+    let (outboard, data) = match db.get(&hash) {
+        // We only respond to requests for collections, not individual blobs
+        Some(BlobOrCollection::Collection(d)) => d,
+        _ => {
+            debug!("not found {}", hash);
+            notify_transfer_aborted(events, connection_id, request.id);
+            write_response(&mut writer, &mut out_buffer, request.id, Res::NotFound).await?;
+            writer.finish().await?;
+
+            return Ok(());
+        }
+    };
+
+    // 5. Transfer data!
+    if let Err(e) = transfer_collection(
+        db.clone(),
+        writer,
+        &mut out_buffer,
+        request.id,
+        outboard,
+        data,
+    )
+    .await
+    {
+        notify_transfer_aborted(events, connection_id, request.id);
+        return Err(e);
     }
 
+    let _ = events.send(Event::TransferCompleted {
+        connection_id,
+        request_id: request.id,
+    });
     Ok(())
 }
 


### PR DESCRIPTION
potentially closes n0-computer/iroh#713 

This refactor splits the `handle_stream` function up into smaller (logical) functions.  If these functions error, we can emit a `TransferAborted` event before returning the error.

This has the added benefit of making the `handle_stream` function a bit easier to take in. None of these new functions have any code changes, the only difference is how errors are handled and when we return.