### PR TITLE
feat: Add option to use SSLKEYLOGFILE env var

### DIFF
--- a/src/get.rs
+++ b/src/get.rs
@@ -33,6 +33,8 @@ pub struct Options {
     pub addr: SocketAddr,
     /// The peer id to expect
     pub peer_id: Option<PeerId>,
+    /// Whether to log the SSL keys when `SSLKEYLOGFILE` environment variable is set.
+    pub keylog: bool,
 }
 
 impl Default for Options {
@@ -40,6 +42,7 @@ impl Default for Options {
         Options {
             addr: "127.0.0.1:4433".parse().unwrap(),
             peer_id: None,
+            keylog: false,
         }
     }
 }
@@ -48,7 +51,7 @@ impl Default for Options {
 async fn setup(opts: Options) -> Result<quinn::Connection> {
     let keypair = Keypair::generate();
 
-    let tls_client_config = tls::make_client_config(&keypair, opts.peer_id)?;
+    let tls_client_config = tls::make_client_config(&keypair, opts.peer_id, opts.keylog)?;
     let mut client_config = quinn::ClientConfig::new(Arc::new(tls_client_config));
     let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap())?;
     let mut transport_config = quinn::TransportConfig::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ mod tests {
             let opts = get::Options {
                 addr,
                 peer_id: Some(peer_id),
+                keylog: true,
             };
             let content = &content;
             let name = &name;
@@ -224,6 +225,7 @@ mod tests {
         let opts = get::Options {
             addr: provider.listen_addr(),
             peer_id: Some(provider.peer_id()),
+            keylog: true,
         };
 
         let i = AtomicUsize::new(0);
@@ -325,6 +327,7 @@ mod tests {
             get::Options {
                 addr: provider_addr,
                 peer_id: None,
+                keylog: true,
             },
             || async move { Ok(()) },
             |_collection| async move { Ok(()) },
@@ -373,6 +376,7 @@ mod tests {
                 get::Options {
                     addr: provider_addr,
                     peer_id: None,
+                    keylog: true,
                 },
                 || async move { Ok(()) },
                 |_collection| async move { Ok(()) },


### PR DESCRIPTION
This adds support for the SSLKEYLOGFILE environment variable which is
a common standard used by browsers to log the TLS keys used for
connections.  It allows traffic inspectors like tcpdump and wireshark
to use the logged keys and decrypt the traffic.  Using this is a first
step to allowing us to observe our protocol on the wire.

The support is still hidden behind a commandline option so that it can
not be accidentally enabled by only having an environment variable
set.